### PR TITLE
feat: add accounts command to list configured accounts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { handleMailCommand } from "./commands/mail.ts";
 import { handleCalCommand } from "./commands/cal.ts";
 import { handleContactsCommand } from "./commands/contacts.ts";
+import { handleAccountsCommand } from "./commands/accounts.ts";
 import { parseAccount } from "./utils/args.ts";
 
 function printHelp() {
@@ -16,6 +17,7 @@ Commands:
   mail           Gmail operations
   cal            Google Calendar operations
   contacts       Google Contacts operations
+  accounts       List configured Google accounts
 
 Options:
   -h, --help              Show this help message
@@ -269,6 +271,9 @@ async function main() {
       break;
     case "contacts":
       await handleContacts(commandArgs);
+      break;
+    case "accounts":
+      await handleAccountsCommand(commandArgs);
       break;
     default:
       console.error(`Unknown command: ${command}`);

--- a/src/commands/accounts.ts
+++ b/src/commands/accounts.ts
@@ -1,0 +1,60 @@
+
+import chalk from "chalk";
+import ora from "ora";
+import { TokenStore } from "../services/token-store.ts";
+import { groupBy } from "lodash-es";
+
+export async function handleAccountsCommand(args: string[]) {
+  const spinner = ora("Fetching configured accounts...").start();
+
+  try {
+    const tokenStore = TokenStore.getInstance();
+    const tokens = tokenStore.listTokens();
+
+    if (tokens.length === 0) {
+      spinner.stop();
+      console.log(chalk.yellow("No configured accounts found."));
+      console.log(`Run ${chalk.cyan("gwork <service> <command>")} to authenticate.`);
+      return;
+    }
+
+    spinner.succeed(`Found ${tokens.length} token(s)`);
+
+    // Group tokens by account email
+    const accounts = groupBy(tokens, "account");
+
+    console.log(chalk.bold("\nConfigured Accounts:"));
+    console.log("─".repeat(80));
+
+    Object.entries(accounts).forEach(([email, accountTokens], index) => {
+      console.log(`\n${chalk.bold(`${index + 1}.`)} ${chalk.cyan(email)}`);
+
+      accountTokens.forEach(token => {
+        const expiryDate = new Date(token.expiry_date);
+        const isExpired = expiryDate.getTime() < Date.now();
+        const statusColor = isExpired ? chalk.red : chalk.green;
+        const statusText = isExpired ? "Expired" : "Active";
+
+        console.log(`   ${chalk.gray("Service:")} ${token.service}`);
+        console.log(`   ${chalk.gray("Status:")}  ${statusColor(statusText)} (${expiryDate.toLocaleString()})`);
+
+        // Show scopes in a condensed way if verbose flag is present
+        if (args.includes("-v") || args.includes("--verbose")) {
+            console.log(`   ${chalk.gray("Scopes:")}`);
+            token.scopes.forEach(scope => {
+                console.log(`     - ${scope}`);
+            });
+        }
+      });
+    });
+
+    // Clean up
+    tokenStore.close();
+    process.exit(0);
+
+  } catch (error: any) {
+    spinner.fail("Failed to list accounts");
+    console.error(chalk.red("Error:"), error.message);
+    process.exit(1);
+  }
+}

--- a/tests/unit/commands/accounts.test.ts
+++ b/tests/unit/commands/accounts.test.ts
@@ -1,0 +1,139 @@
+
+import { describe, test, expect, spyOn, beforeEach, afterEach, mock } from "bun:test";
+import { handleAccountsCommand } from "../../../src/commands/accounts.ts";
+import { TokenStore } from "../../../src/services/token-store.ts";
+import chalk from "chalk";
+
+// Mock ora
+mock.module("ora", () => {
+  return {
+    default: () => ({
+      start: () => ({
+        stop: () => {},
+        succeed: () => {},
+        fail: () => {},
+      }),
+    }),
+  };
+});
+
+describe("handleAccountsCommand", () => {
+  let originalExit: any;
+  let exitSpy: any;
+  let consoleLogSpy: any;
+  let originalTokenStoreInstance: any;
+  let originalGetInstance: any;
+
+  beforeEach(() => {
+    // Mock process.exit
+    originalExit = process.exit;
+    exitSpy = spyOn(process, "exit").mockImplementation((() => {}) as any);
+
+    // Spy on console.log
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    // Save original TokenStore instance and getInstance method
+    originalTokenStoreInstance = (TokenStore as any).instance;
+    originalGetInstance = TokenStore.getInstance;
+
+    // Reset TokenStore instance
+    (TokenStore as any).instance = null;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+
+    // Restore TokenStore
+    if ((TokenStore as any).instance) {
+        try {
+            // Check if close exists before calling it (it might be our mock)
+            if (typeof (TokenStore as any).instance.close === 'function') {
+                (TokenStore as any).instance.close();
+            }
+        } catch (e) {}
+    }
+    (TokenStore as any).instance = originalTokenStoreInstance;
+    TokenStore.getInstance = originalGetInstance;
+  });
+
+  test("displays message when no accounts configured", async () => {
+    // Mock TokenStore to return empty list
+    const mockListTokens = mock(() => []);
+    const mockClose = mock(() => {});
+
+    (TokenStore as any).getInstance = () => ({
+      listTokens: mockListTokens,
+      close: mockClose,
+    });
+
+    await handleAccountsCommand([]);
+
+    expect(mockListTokens).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(chalk.yellow("No configured accounts found."));
+    // Expect implicit return (undefined) rather than exit(0) in the early return case?
+    // Looking at the code:
+    // if (tokens.length === 0) { ... return; }
+    // So process.exit is NOT called in this case.
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("lists configured accounts", async () => {
+    // Mock TokenStore to return some tokens
+    const tokens = [
+      {
+        service: "gmail",
+        account: "test@example.com",
+        expiry_date: Date.now() + 10000,
+        scopes: ["scope1"],
+      },
+      {
+        service: "calendar",
+        account: "test@example.com",
+        expiry_date: Date.now() - 10000, // Expired
+        scopes: ["scope2"],
+      }
+    ];
+
+    const mockListTokens = mock(() => tokens);
+    const mockClose = mock(() => {});
+
+    (TokenStore as any).getInstance = () => ({
+      listTokens: mockListTokens,
+      close: mockClose,
+    });
+
+    await handleAccountsCommand([]);
+
+    expect(mockListTokens).toHaveBeenCalled();
+    // Verify some output
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("test@example.com"));
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  test("shows scopes when verbose flag is used", async () => {
+    const tokens = [
+        {
+          service: "gmail",
+          account: "test@example.com",
+          expiry_date: Date.now() + 10000,
+          scopes: ["https://mail.google.com/"],
+        }
+      ];
+
+      const mockListTokens = mock(() => tokens);
+      const mockClose = mock(() => {});
+
+      (TokenStore as any).getInstance = () => ({
+        listTokens: mockListTokens,
+        close: mockClose,
+      });
+
+      await handleAccountsCommand(["--verbose"]);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Scopes:"));
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("https://mail.google.com/"));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new `accounts` command to list all configured Google accounts in the token store.
This allows users to see which accounts are authenticated and their status (Active/Expired).

## Changes
- Created `src/commands/accounts.ts` to implement the `handleAccountsCommand` function.
- Updated `src/cli.ts` to register the `accounts` command.
- Added unit tests in `tests/unit/commands/accounts.test.ts`.

## Test Plan
- Run `bun test` to verify unit tests pass.
- Run `gwork accounts` to see the list of accounts.
- Run `gwork accounts -v` to see scopes.

Resolves #3