### PR TITLE
fix(commands): add radix 10 and NaN guards to all parseInt calls

### DIFF
--- a/src/commands/cal.ts
+++ b/src/commands/cal.ts
@@ -179,10 +179,10 @@ async function listEvents(calendarService: CalendarService, args: string[]) {
         if (value) options.calendar = value;
       } else if (arg === "-n" || arg === "--max") {
         const value = args[++i];
-        if (value) options.max = parseInt(value);
+        if (value) options.max = parseInt(value, 10);
       } else if (arg === "--days") {
         const value = args[++i];
-        if (value) options.days = parseInt(value);
+        if (value) options.days = parseInt(value, 10);
       } else if (arg === "--range") {
         const value = args[++i];
         if (value) options.range = value;
@@ -524,7 +524,7 @@ async function createEvent(calendarService: CalendarService, calendarId: string,
       endTime = new Date(options.end);
     } else {
       endTime = new Date(
-        startTime.getTime() + parseInt(options.duration || "60") * 60000
+        startTime.getTime() + parseInt(options.duration || "60", 10) * 60000
       );
     }
 
@@ -683,14 +683,14 @@ async function searchEvents(calendarService: CalendarService, query: string, ext
       
       if (arg === "--max-results" || arg === "-n") {
         const value = extraArgs[++i];
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-c" || arg === "--calendar") {
         const value = extraArgs[++i];
         if (value) options.calendar = value;
       } else if (arg === "--days") {
         const value = extraArgs[++i];
         if (value) {
-          const days = parseInt(value);
+          const days = parseInt(value, 10);
           const timeMin = new Date();
           const timeMax = new Date();
           timeMax.setDate(timeMax.getDate() + days);
@@ -836,7 +836,7 @@ async function getStats(calendarService: CalendarService, args: string[]) {
         if (value) options.calendar = value;
       } else if (arg === "--days") {
         const value = args[++i];
-        if (value) options.days = parseInt(value);
+        if (value) options.days = parseInt(value, 10);
       }
     }
 
@@ -1251,7 +1251,7 @@ async function manageReminders(
         if (!arg) continue;
         if (arg === "--minutes") {
           const value = args[++i];
-          if (value) minutes = parseInt(value);
+          if (value) minutes = parseInt(value, 10);
         }
       }
 
@@ -1274,7 +1274,7 @@ async function manageReminders(
         if (!arg) continue;
         if (arg === "--index") {
           const value = args[++i];
-          if (value) index = parseInt(value) - 1;
+          if (value) index = parseInt(value, 10) - 1;
         }
       }
 
@@ -1585,7 +1585,7 @@ async function checkConflict(calendarService: CalendarService, calendarId: strin
         if (value) options.calendars = map(compact(value.split(",")), (id: string) => id.trim());
       } else if (arg === "--duration") {
         const value = args[++i];
-        if (value) options.duration = parseInt(value);
+        if (value) options.duration = parseInt(value, 10);
       }
     }
 
@@ -1905,7 +1905,7 @@ async function manageColor(calendarService: CalendarService, args: string[]) {
       }
       const calendarId = args[1];
       const eventId = args[2];
-      const colorId = parseInt(args[3]);
+      const colorId = parseInt(args[3], 10);
 
       if (isNaN(colorId) || colorId < 1 || colorId > 11) {
         throw new ArgumentError("Invalid color ID", "Color ID must be between 1 and 11");
@@ -1965,7 +1965,7 @@ async function workWithRecurrence(args: string[]) {
         if (!arg) continue;
         if (arg === "--count") {
           const value = args[++i];
-          if (value) count = parseInt(value);
+          if (value) count = parseInt(value, 10);
         }
       }
 
@@ -2036,7 +2036,7 @@ async function createRecurringEvent(calendarService: CalendarService, calendarId
         if (value) options.frequency = value;
       } else if (arg === "--count") {
         const value = args[++i];
-        if (value) options.count = parseInt(value);
+        if (value) options.count = parseInt(value, 10);
       } else if (arg === "--until") {
         const value = args[++i];
         if (value) options.until = value;
@@ -2084,7 +2084,7 @@ async function createRecurringEvent(calendarService: CalendarService, calendarId
       endTime = new Date(options.end);
     } else {
       endTime = new Date(
-        startTime.getTime() + parseInt(options.duration || "60") * 60000
+        startTime.getTime() + parseInt(options.duration || "60", 10) * 60000
       );
     }
 
@@ -2215,7 +2215,7 @@ async function dateUtilities(args: string[]) {
     }
 
     let date = new Date(args[1]);
-    const amount = parseInt(args[2]);
+    const amount = parseInt(args[2], 10);
     const unit = args[3].toLowerCase();
 
     if (unit === "days" || unit === "day") {

--- a/src/commands/contacts.ts
+++ b/src/commands/contacts.ts
@@ -157,7 +157,7 @@ async function listContacts(contactsService: ContactsService, args: string[]) {
 
       if (arg === "-n" || arg === "--max") {
         const value = args[++i]!;
-        if (value) options.max = parseInt(value);
+        if (value) options.max = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -283,7 +283,7 @@ async function searchContacts(contactsService: ContactsService, query: string, a
 
       if (arg === "-n" || arg === "--max") {
         const value = args[++i]!;
-        if (value) options.max = parseInt(value);
+        if (value) options.max = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -912,10 +912,10 @@ async function autoMergeContacts(contactsService: ContactsService, args: string[
         if (value) options.criteria = value.split(",").map((c) => c.trim());
       } else if (arg === "--threshold" || arg === "-t") {
         const value = args[++i]!;
-        if (value) options.threshold = parseInt(value);
+        if (value) options.threshold = parseInt(value, 10);
       } else if (arg === "--max-results" || arg === "-n") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       }
     }
 
@@ -1002,10 +1002,10 @@ async function findDuplicates(contactsService: ContactsService, args: string[]) 
         if (value) options.criteria = value.split(",").map((c) => c.trim());
       } else if (arg === "--threshold" || arg === "-t") {
         const value = args[++i]!;
-        if (value) options.threshold = parseInt(value);
+        if (value) options.threshold = parseInt(value, 10);
       } else if (arg === "--max-results" || arg === "-n") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -1123,7 +1123,7 @@ async function findMissingNames(contactsService: ContactsService, args: string[]
 
       if (arg === "-n" || arg === "--max-results") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -1194,7 +1194,7 @@ async function analyzeGenericNames(contactsService: ContactsService, args: strin
 
       if (arg === "-n" || arg === "--max-results") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -1265,7 +1265,7 @@ async function analyzeImportedContacts(contactsService: ContactsService, args: s
 
       if (arg === "-n" || arg === "--max-results") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;
@@ -1353,7 +1353,7 @@ async function detectMarketing(contactsService: ContactsService, args: string[])
 
       if (arg === "-n" || arg === "--max-results") {
         const value = args[++i]!;
-        if (value) options.maxResults = parseInt(value);
+        if (value) options.maxResults = parseInt(value, 10);
       } else if (arg === "-f" || arg === "--format") {
         const value = args[++i]!;
         if (value) options.format = value;

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -283,7 +283,8 @@ async function listMessages(mailService: MailService, args: string[]) {
     for (let i = 0; i < args.length; i++) {
       if (args[i] === "--max-results" || args[i] === "-n") {
         if (i + 1 < args.length) {
-          options.maxResults = parseInt(args[++i]!);
+          const parsed = parseInt(args[++i]!, 10);
+          if (!isNaN(parsed)) options.maxResults = parsed;
         }
       } else if (args[i] === "--query" || args[i] === "-q") {
         if (i + 1 < args.length) {
@@ -386,7 +387,8 @@ async function searchMessages(mailService: MailService, query: string, extraArgs
     for (let i = 0; i < extraArgs.length; i++) {
       if (extraArgs[i] === "--max-results" || extraArgs[i] === "-n") {
         if (i + 1 < extraArgs.length) {
-          options.maxResults = parseInt(extraArgs[++i]!);
+          const parsed = parseInt(extraArgs[++i]!, 10);
+          if (!isNaN(parsed)) options.maxResults = parsed;
         }
       } else if (extraArgs[i] === "--page-token") {
         if (i + 1 < extraArgs.length) {
@@ -486,7 +488,10 @@ async function listThreads(mailService: MailService, args: string[]) {
 
     for (let i = 0; i < args.length; i++) {
       if (args[i] === "--max-results" || args[i] === "-n") {
-        options.maxResults = parseInt(args[++i]!);
+        if (i + 1 < args.length) {
+          const parsed = parseInt(args[++i]!, 10);
+          if (!isNaN(parsed)) options.maxResults = parsed;
+        }
       } else if (args[i] === "--query" || args[i] === "-q") {
         options.q = args[++i]!;
       }


### PR DESCRIPTION
## Summary

- Adds `parseInt(..., 10)` to all argument parsers in `mail.ts`, `cal.ts`, and `contacts.ts` to prevent hex/octal misinterpretation
- Adds `isNaN` guards in `mail.ts` so a bad `--max-results` value falls back to the default rather than sending `NaN` to the Google API
- Fixes missing bounds check in `listThreads` (`mail.ts`) where `args[++i]` could access `undefined` when `--max-results` was the last argument

## Test plan

- [ ] `bun run lint` passes
- [ ] `bun test` passes (148 tests)
- [ ] `gwork mail messages -n 5` works correctly
- [ ] `gwork mail messages -n 0x10` no longer sends 16 to the API

Fixes #30