### PR TITLE
fix(commands): replace console.log calls with unified logger

### DIFF
--- a/src/commands/cal.ts
+++ b/src/commands/cal.ts
@@ -631,9 +631,9 @@ async function updateEvent(
     );
     spinner.succeed("Event updated successfully");
 
-    console.log(chalk.green(`\nEvent updated:`));
-    console.log(`${chalk.cyan("Title:")} ${event.summary}`);
-    console.log(`${chalk.cyan("ID:")} ${event.id}`);
+    logger.info(chalk.green(`\nEvent updated:`));
+    logger.info(`${chalk.cyan("Title:")} ${event.summary}`);
+    logger.info(`${chalk.cyan("ID:")} ${event.id}`);
   } catch (error: unknown) {
     spinner.fail("Failed to update event");
     throw error;
@@ -656,7 +656,7 @@ async function deleteEvent(
   try {
     await calendarService.deleteEvent(calendarId, eventId);
     spinner.succeed("Event deleted successfully");
-    console.log(chalk.green("Event has been deleted"));
+    logger.info(chalk.green("Event has been deleted"));
   } catch (error: unknown) {
     spinner.fail("Failed to delete event");
     throw error;
@@ -809,10 +809,10 @@ async function createCalendar(calendarService: CalendarService, title: string) {
     const calendar = await calendarService.createCalendar(calendarData);
     spinner.succeed("Calendar created successfully");
 
-    console.log(chalk.green(`\nCalendar created:`));
-    console.log(`${chalk.cyan("Title:")} ${calendar.summary ?? "Unknown"}`);
-    console.log(`${chalk.cyan("ID:")} ${calendar.id ?? "Unknown"}`);
-    console.log(`${chalk.cyan("Timezone:")} ${calendar.timeZone ?? "Unknown"}`);
+    logger.info(chalk.green(`\nCalendar created:`));
+    logger.info(`${chalk.cyan("Title:")} ${calendar.summary ?? "Unknown"}`);
+    logger.info(`${chalk.cyan("ID:")} ${calendar.id ?? "Unknown"}`);
+    logger.info(`${chalk.cyan("Timezone:")} ${calendar.timeZone ?? "Unknown"}`);
   } catch (error: unknown) {
     spinner.fail("Failed to create calendar");
     throw error;
@@ -1934,10 +1934,10 @@ async function workWithRecurrence(args: string[]) {
   const spinner = ora("Working with recurrence...").start();
   try {
     if (args.length === 0 || args[0] === "help") {
-      console.log(chalk.bold("\nRecurrence Utilities:"));
-      console.log("─".repeat(80));
-      console.log("Parse RRULE: gwork cal recurrence parse <rrule>");
-      console.log("Show occurrences: gwork cal recurrence occurrences <rrule> [--count N]");
+      logger.info(chalk.bold("\nRecurrence Utilities:"));
+      logger.info("─".repeat(80));
+      logger.info("Parse RRULE: gwork cal recurrence parse <rrule>");
+      logger.info("Show occurrences: gwork cal recurrence occurrences <rrule> [--count N]");
       return;
     }
 
@@ -2121,7 +2121,7 @@ async function showRecurrenceInfo(calendarService: CalendarService, calendarId: 
 
     if (!event.recurrence || event.recurrence.length === 0) {
       spinner.succeed("Event is not recurring");
-      console.log(chalk.yellow("This event does not have recurrence rules"));
+      logger.info(chalk.yellow("This event does not have recurrence rules"));
       return;
     }
 
@@ -2160,12 +2160,12 @@ async function showRecurrenceInfo(calendarService: CalendarService, calendarId: 
 
 async function dateUtilities(args: string[]) {
   if (args.length === 0 || args[0] === "help") {
-    console.log(chalk.bold("\nDate Utilities:"));
-    console.log("─".repeat(80));
-    console.log("Format: gwork cal date format <date> [--format <format>]");
-    console.log("Parse: gwork cal date parse <dateString>");
-    console.log("Add: gwork cal date add <date> <amount> <unit>");
-    console.log("Diff: gwork cal date diff <date1> <date2>");
+    logger.info(chalk.bold("\nDate Utilities:"));
+    logger.info("─".repeat(80));
+    logger.info("Format: gwork cal date format <date> [--format <format>]");
+    logger.info("Parse: gwork cal date parse <dateString>");
+    logger.info("Add: gwork cal date add <date> <amount> <unit>");
+    logger.info("Diff: gwork cal date diff <date1> <date2>");
     return;
   }
 
@@ -2200,15 +2200,15 @@ async function dateUtilities(args: string[]) {
       relative: formatDistance(date, new Date(), { addSuffix: true }),
     };
 
-    console.log(formatMap[formatStr] || date.toISOString());
+    logger.info(formatMap[formatStr] || date.toISOString());
   } else if (action === "parse") {
     if (args.length < 2 || !args[1]) {
       throw new ArgumentError("Missing date argument", "Usage: gwork cal date parse <dateString>");
     }
 
     const date = new Date(args[1]);
-    console.log(`Parsed: ${date.toISOString()}`);
-    console.log(`Formatted: ${formatDate(date, "MMMM d, yyyy 'at' h:mm a")}`);
+    logger.info(`Parsed: ${date.toISOString()}`);
+    logger.info(`Formatted: ${formatDate(date, "MMMM d, yyyy 'at' h:mm a")}`);
   } else if (action === "add") {
     if (args.length < 4 || !args[1] || !args[2] || !args[3]) {
       throw new ArgumentError("Missing arguments", "Usage: gwork cal date add <date> <amount> <unit>");
@@ -2228,7 +2228,7 @@ async function dateUtilities(args: string[]) {
       throw new ArgumentError("Invalid unit", "Use: days, weeks, months");
     }
 
-    console.log(date.toISOString());
+    logger.info(date.toISOString());
   } else if (action === "diff") {
     if (args.length < 3 || !args[1] || !args[2]) {
       throw new ArgumentError("Missing arguments", "Usage: gwork cal date diff <date1> <date2>");
@@ -2239,8 +2239,8 @@ async function dateUtilities(args: string[]) {
     const days = differenceInDays(date2, date1);
     const hours = differenceInHours(date2, date1);
 
-    console.log(`Difference: ${days} days (${hours} hours)`);
-    console.log(`Relative: ${formatDistance(date2, date1)}`);
+    logger.info(`Difference: ${days} days (${hours} hours)`);
+    logger.info(`Relative: ${formatDistance(date2, date1)}`);
   } else {
     throw new ArgumentError("Invalid action", "Use: format, parse, add, diff");
   }

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -662,7 +662,7 @@ async function deleteMessage(mailService: MailService, messageId: string) {
   try {
     await mailService.deleteMessage(messageId);
     spinner.succeed("Message deleted");
-    console.log(chalk.green("Message has been deleted"));
+    logger.info(chalk.green("Message has been deleted"));
   } catch (error: unknown) {
     spinner.fail("Failed to delete message");
     throw error;
@@ -699,7 +699,7 @@ async function archiveMessage(mailService: MailService, messageId: string) {
   try {
     await mailService.archiveMessage(messageId);
     spinner.succeed("Message archived");
-    console.log(chalk.green("Message has been archived"));
+    logger.info(chalk.green("Message has been archived"));
   } catch (error: unknown) {
     spinner.fail("Failed to archive message");
     throw error;
@@ -745,7 +745,7 @@ async function unarchiveMessage(mailService: MailService, messageId: string) {
   try {
     await mailService.unarchiveMessage(messageId);
     spinner.succeed("Message unarchived");
-    console.log(chalk.green("Message has been unarchived"));
+    logger.info(chalk.green("Message has been unarchived"));
   } catch (error: unknown) {
     spinner.fail("Failed to unarchive message");
     throw error;
@@ -800,7 +800,7 @@ async function addLabel(mailService: MailService, messageId: string, labelName: 
 
     await mailService.modifyMessage(messageId, [label.id], []);
     spinner.succeed("Label added");
-    console.log(chalk.green(`Label "${label.name}" added to message`));
+    logger.info(chalk.green(`Label "${label.name}" added to message`));
   } catch (error: unknown) {
     spinner.fail("Failed to add label");
     throw error;
@@ -820,7 +820,7 @@ async function removeLabel(mailService: MailService, messageId: string, labelNam
 
     await mailService.modifyMessage(messageId, [], [label.id]);
     spinner.succeed("Label removed");
-    console.log(chalk.green(`Label "${label.name}" removed from message`));
+    logger.info(chalk.green(`Label "${label.name}" removed from message`));
   } catch (error: unknown) {
     spinner.fail("Failed to remove label");
     throw error;
@@ -832,7 +832,7 @@ async function markRead(mailService: MailService, messageId: string) {
   try {
     await mailService.modifyMessage(messageId, [], ["UNREAD"]);
     spinner.succeed("Message marked as read");
-    console.log(chalk.green("Message has been marked as read"));
+    logger.info(chalk.green("Message has been marked as read"));
   } catch (error: unknown) {
     spinner.fail("Failed to mark message as read");
     throw error;
@@ -844,7 +844,7 @@ async function markUnread(mailService: MailService, messageId: string) {
   try {
     await mailService.modifyMessage(messageId, ["UNREAD"], []);
     spinner.succeed("Message marked as unread");
-    console.log(chalk.green("Message has been marked as unread"));
+    logger.info(chalk.green("Message has been marked as unread"));
   } catch (error: unknown) {
     spinner.fail("Failed to mark message as unread");
     throw error;
@@ -856,7 +856,7 @@ async function starMessage(mailService: MailService, messageId: string) {
   try {
     await mailService.modifyMessage(messageId, ["STARRED"], []);
     spinner.succeed("Message starred");
-    console.log(chalk.green("Message has been starred"));
+    logger.info(chalk.green("Message has been starred"));
   } catch (error: unknown) {
     spinner.fail("Failed to star message");
     throw error;
@@ -868,7 +868,7 @@ async function unstarMessage(mailService: MailService, messageId: string) {
   try {
     await mailService.modifyMessage(messageId, [], ["STARRED"]);
     spinner.succeed("Message unstarred");
-    console.log(chalk.green("Message has been unstarred"));
+    logger.info(chalk.green("Message has been unstarred"));
   } catch (error: unknown) {
     spinner.fail("Failed to unstar message");
     throw error;
@@ -900,8 +900,8 @@ async function createLabel(mailService: MailService, labelName: string, args: st
 
     const label = await mailService.createLabel(labelData);
     spinner.succeed("Label created");
-    console.log(chalk.green(`Label "${label.name}" created`));
-    console.log(`${chalk.cyan("Label ID:")} ${label.id}`);
+    logger.info(chalk.green(`Label "${label.name}" created`));
+    logger.info(`${chalk.cyan("Label ID:")} ${label.id}`);
   } catch (error: unknown) {
     spinner.fail("Failed to create label");
     throw error;
@@ -913,7 +913,7 @@ async function deleteLabel(mailService: MailService, labelId: string) {
   try {
     await mailService.deleteLabel(labelId);
     spinner.succeed("Label deleted");
-    console.log(chalk.green("Label has been deleted"));
+    logger.info(chalk.green("Label has been deleted"));
   } catch (error: unknown) {
     spinner.fail("Failed to delete label");
     throw error;


### PR DESCRIPTION
## Summary

24 `console.log` calls in `mail.ts` and `cal.ts` bypassed the unified logger, meaning `--quiet` and `--verbose` flags had no effect on that output.

**Changes:**
- Replace all 11 `console.log` calls in `mail.ts` with `logger.info()`
- Replace all 13 `console.log` calls in `cal.ts` with `logger.info()`

## Test plan

- [ ] `bun run lint` — clean
- [ ] `bun test` — 150 tests pass
- [ ] `gwork mail delete <id> --quiet` suppresses success message

Fixes #33