### PR TITLE
refactor(logging): unify Logger types so --quiet/--verbose apply to services

### DIFF
--- a/src/services/auth-manager.ts
+++ b/src/services/auth-manager.ts
@@ -25,7 +25,7 @@ import { google } from "googleapis";
 import { authenticate } from "@google-cloud/local-auth";
 import type { AuthClient } from "../types/google-apis.ts";
 import type { TokenStore } from "./token-store.ts";
-import type { Logger } from "./logger.ts";
+import type { Logger } from "../utils/logger.ts";
 import type { TokenData } from "./token-store.ts";
 import * as fs from "fs/promises";
 

--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -10,8 +10,8 @@
 
 import { ensureCredentialsExist } from "../utils/setup-guide.ts";
 import { InitializationError } from "./errors.ts";
-import { defaultLogger } from "./logger.ts";
-import type { Logger } from "./logger.ts";
+import { logger as defaultLogger } from "../utils/logger.ts";
+import type { Logger } from "../utils/logger.ts";
 import type { AuthClient } from "../types/google-apis.ts";
 import { AuthManager } from "./auth-manager.ts";
 import { TokenStore } from "./token-store.ts";

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,53 +1,6 @@
 /**
- * Logger interface and console implementation.
- * Decouples services from console.log to enable structured logging.
+ * @deprecated Import from "../utils/logger.ts" instead.
+ * This file re-exports the unified Logger interface and singleton for backwards compatibility.
  */
-
-export interface Logger {
-  info(message: string, meta?: any): void;
-  warn(message: string, meta?: any): void;
-  error(message: string, meta?: any): void;
-  debug(message: string, meta?: any): void;
-}
-
-/**
- * Simple console-based logger implementation.
- * Debug messages only shown when DEBUG environment variable is set.
- */
-export class ConsoleLogger implements Logger {
-  info(message: string, meta?: any): void {
-    if (meta) {
-      console.log(message, JSON.stringify(meta));
-    } else {
-      console.log(message);
-    }
-  }
-
-  warn(message: string, meta?: any): void {
-    if (meta) {
-      console.warn(message, JSON.stringify(meta));
-    } else {
-      console.warn(message);
-    }
-  }
-
-  error(message: string, meta?: any): void {
-    if (meta) {
-      console.error(message, JSON.stringify(meta));
-    } else {
-      console.error(message);
-    }
-  }
-
-  debug(message: string, meta?: any): void {
-    if (process.env["DEBUG"]) {
-      if (meta) {
-        console.debug(message, JSON.stringify(meta));
-      } else {
-        console.debug(message);
-      }
-    }
-  }
-}
-
-export const defaultLogger = new ConsoleLogger();
+export type { Logger } from "../utils/logger.ts";
+export { logger as defaultLogger } from "../utils/logger.ts";

--- a/src/utils/db-retry.ts
+++ b/src/utils/db-retry.ts
@@ -103,8 +103,8 @@
  * @see {@link TokenStore} for usage examples
  */
 
-import { defaultLogger } from "../services/logger.ts";
-import type { Logger } from "../services/logger.ts";
+import { logger as defaultLogger } from "./logger.ts";
+import type { Logger } from "./logger.ts";
 
 export interface DbRetryOptions {
   maxRetries?: number;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,13 +5,25 @@
 
 export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 
+/**
+ * Shared Logger interface used across commands and services.
+ * The singleton `logger` instance implements this interface and respects
+ * --quiet / --verbose flags configured via `logger.configure()`.
+ */
+export interface Logger {
+  error(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+}
+
 interface LoggerConfig {
   level: LogLevel;
   quiet: boolean;
   verbose: boolean;
 }
 
-class Logger {
+class LoggerImpl implements Logger {
   private config: LoggerConfig = {
     level: 'info',
     quiet: false,
@@ -83,4 +95,4 @@ class Logger {
 }
 
 // Export singleton instance
-export const logger = new Logger();
+export const logger = new LoggerImpl();


### PR DESCRIPTION
## Summary

- Exports a shared `Logger` interface from `src/utils/logger.ts` with `...args: unknown[]` signatures (no `any`)
- Renames the internal `Logger` class to `LoggerImpl` to avoid the name conflict with the new interface
- Replaces `src/services/logger.ts` with a re-export shim (`export type { Logger }` + `export { logger as defaultLogger }`) pointing to utils
- Updates `BaseService` to default to the singleton `logger` from `src/utils/logger.ts` — so `logger.configure({ quiet, verbose })` in `cli.ts` now affects all service-layer output
- Updates `src/services/auth-manager.ts` and `src/utils/db-retry.ts` to import `Logger` from utils

## Acceptance criteria verified

- [x] Single `Logger` interface/type used across commands and services
- [x] `--quiet` suppresses log output from service-layer methods (BaseService now uses the configured singleton)
- [x] `--verbose` enables debug output from services
- [x] No `any` in logger type signatures
- [x] `src/services/logger.ts` replaced with re-export shim (backwards compatible)
- [x] `pnpm typecheck` (`bunx tsc --noEmit`) passes
- [x] `pnpm lint` (`bun run lint`) passes
- [x] All 150 tests pass

Fixes #32