### PR TITLE
fix(sqlite): rebuild better-sqlite3 binding if load fails on postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ gwork cal --help
 gwork contacts --help
 ```
 
+### Native binding (pnpm / Node 25+)
+
+`gwork` uses `better-sqlite3` for token storage, which requires a native `.node` binding compiled for your current Node.js ABI. If you install via **pnpm** or switch Node versions and see an error like:
+
+```
+Error: Could not locate the bindings file. Tried: .../better_sqlite3.node
+```
+
+Rebuild the native binding for your current Node version:
+
+```bash
+pnpm rebuild better-sqlite3
+# or
+npm rebuild better-sqlite3
+```
+
 ## Usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "bun src/cli.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "postinstall": "npm list better-sqlite3 2>/dev/null | grep -q better-sqlite3 || npm install better-sqlite3 2>/dev/null || true",
+    "postinstall": "node -e \"require('better-sqlite3')\" 2>/dev/null || npm rebuild better-sqlite3 2>/dev/null || npm install better-sqlite3 2>/dev/null || true",
     "prepublishOnly": "bun run build",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/src/utils/sqlite-wrapper.ts
+++ b/src/utils/sqlite-wrapper.ts
@@ -18,8 +18,11 @@ if (isBun) {
     const errorMsg = (error as any)?.message || String(error);
     if (errorMsg.includes("ERR_MODULE_NOT_FOUND") || errorMsg.includes("better-sqlite3")) {
       console.error(
-        "\n❌ Error: better-sqlite3 is not installed.\n" +
-          "To fix this, run: npm install better-sqlite3\n" +
+        "\n❌ Error: better-sqlite3 native binding could not be loaded.\n" +
+          "This usually means the binding needs to be compiled for your current Node.js version.\n" +
+          "To fix this, run one of:\n" +
+          "  npm rebuild better-sqlite3\n" +
+          "  pnpm rebuild better-sqlite3\n" +
           "Or reinstall gwork: npm install -g gwork\n"
       );
       process.exit(1);


### PR DESCRIPTION
## Summary

Fixes #45 — `better-sqlite3` native binding fails when running from a local pnpm dev checkout on Node 25.

## Root Cause

The old `postinstall` script checked whether `better-sqlite3` was *listed* (`npm list better-sqlite3`) but not whether its native `.node` binding actually *loads*. When pnpm installs the package, the binding may be compiled for a different Node ABI, causing the binding lookup to fail at runtime.

## Changes

- **`package.json` `postinstall`**: Now attempts `node -e "require('better-sqlite3')"` first. If that fails (binding missing or wrong ABI), runs `npm rebuild better-sqlite3` to recompile for the current Node version, then falls back to `npm install better-sqlite3` as a last resort.
- **`src/utils/sqlite-wrapper.ts`**: Improved error message to explain the ABI mismatch and show the `pnpm rebuild better-sqlite3` / `npm rebuild better-sqlite3` fix commands.
- **`README.md`**: Added a "Native binding (pnpm / Node 25+)" section under Development with the rebuild command for developers hitting this issue.

## Verification

- `bunx tsc --noEmit` ✓
- `bun run lint` ✓