### PR TITLE
refactor(commands): replace switch-based dispatch with command registry (#47)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { handleMailCommand } from "./commands/mail.ts";
 import { handleCalCommand } from "./commands/cal.ts";
 import { handleContactsCommand } from "./commands/contacts.ts";
 import { handleAccountsCommand } from "./commands/accounts.ts";
+import { CommandRegistry } from "./commands/registry.ts";
 import { parseAccount } from "./utils/args.ts";
 import { logServiceError } from "./utils/command-error-handler.ts";
 import { logger } from "./utils/logger.ts";
@@ -308,25 +309,14 @@ async function main() {
   // Pass remaining args to subcommands
   const commandArgs = filteredArgs.slice(1);
 
-  switch (command) {
-    case "mail":
-      await handleMail(commandArgs);
-      break;
-    case "cal":
-      await handleCal(commandArgs);
-      break;
-    case "contacts":
-      await handleContacts(commandArgs);
-      break;
-    case "accounts":
-      await handleAccountsCommand(commandArgs);
-      break;
-    default:
-      console.error(`Unknown command: ${command}`);
-      console.error("Run 'gwork --help' for usage information");
-      process.exit(1);
-  }
+  await topLevelRegistry.execute(command, null, commandArgs);
 }
+
+const topLevelRegistry = new CommandRegistry<null>()
+  .register("mail", (_svc, args) => handleMail(args))
+  .register("cal", (_svc, args) => handleCal(args))
+  .register("contacts", (_svc, args) => handleContacts(args))
+  .register("accounts", (_svc, args) => handleAccountsCommand(args));
 
 main().catch((error) => {
   logServiceError(error);

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,0 +1,32 @@
+import { ArgumentError } from "../services/errors.ts";
+
+type CommandFn<S> = (service: S, args: string[]) => Promise<void>;
+
+/**
+ * Generic command registry that maps subcommand names to handler functions.
+ * Replaces switch-based dispatch — adding a new subcommand only requires
+ * calling .register(), never editing the dispatcher.
+ */
+export class CommandRegistry<S> {
+  private handlers = new Map<string, CommandFn<S>>();
+
+  register(name: string, fn: CommandFn<S>): this {
+    this.handlers.set(name, fn);
+    return this;
+  }
+
+  async execute(name: string, service: S, args: string[]): Promise<void> {
+    const fn = this.handlers.get(name);
+    if (!fn) {
+      throw new ArgumentError(
+        `Unknown subcommand: ${name}`,
+        [...this.handlers.keys()].join(", ")
+      );
+    }
+    return fn(service, args);
+  }
+
+  commands(): string[] {
+    return [...this.handlers.keys()];
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces a generic `CommandRegistry<S>` class in `src/commands/registry.ts` that maps subcommand names to handler functions via a `Map`
- Replaces the 30-case switch in `mail.ts` with a `buildMailRegistry(account)` factory (captures `account` in closure for the `search` command)
- Replaces the 27-case switch in `cal.ts` with a module-level `calRegistry` constant
- Replaces the 20-case switch in `contacts.ts` with a module-level `contactsRegistry` constant
- Replaces the 4-case switch in `cli.ts` with a `topLevelRegistry` using `CommandRegistry<null>`

Adding a new subcommand now requires only: write the handler + call `.register()`. No switch edits required anywhere.

## Acceptance Criteria Verification

- [x] `CommandRegistry<S>` exists in `src/commands/registry.ts`
- [x] `mail.ts`, `cal.ts`, `contacts.ts` dispatch via registry (no switch statements)
- [x] `cli.ts` top-level dispatch uses registry
- [x] `ArgumentError` thrown for unknown subcommands with full list of valid commands
- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun run lint` passes with no errors

## Test plan

- [ ] `bunx tsc --noEmit` — passes clean
- [ ] `bun run lint` — passes clean
- [ ] `gwork mail messages` routes correctly
- [ ] `gwork cal list` routes correctly
- [ ] `gwork contacts list` routes correctly
- [ ] Unknown subcommand throws `ArgumentError` with valid command list

Fixes #47