### PR TITLE
refactor(commands): accept service factory parameter to enable dependency injection

### DIFF
--- a/src/commands/cal.ts
+++ b/src/commands/cal.ts
@@ -121,9 +121,16 @@ const calRegistry = new CommandRegistry<CalendarService>()
   })
   .register("date", (_svc, args) => dateUtilities(args));
 
-export async function handleCalCommand(subcommand: string, args: string[], account = "default") {
+type CalServiceFactory = (account: string) => CalendarService;
+
+export async function handleCalCommand(
+  subcommand: string,
+  args: string[],
+  account = "default",
+  serviceFactory: CalServiceFactory = (acc) => new CalendarService(acc)
+) {
   // Create service instance with the specified account
-  const calendarService = new CalendarService(account);
+  const calendarService = serviceFactory(account);
 
   // Ensure service is initialized (checks credentials) before any command
   await ensureInitialized(calendarService);

--- a/src/commands/contacts.ts
+++ b/src/commands/contacts.ts
@@ -104,12 +104,15 @@ const contactsRegistry = new CommandRegistry<ContactsService>()
   .register("analyze-imported", (svc, args) => analyzeImportedContacts(svc, args))
   .register("detect-marketing", (svc, args) => detectMarketing(svc, args));
 
+type ContactsServiceFactory = (account: string) => ContactsService;
+
 export async function handleContactsCommand(
   subcommand: string,
   args: string[],
-  account = "default"
+  account = "default",
+  serviceFactory: ContactsServiceFactory = (acc) => new ContactsService(acc)
 ) {
-  const contactsService = new ContactsService(account);
+  const contactsService = serviceFactory(account);
   await ensureInitialized(contactsService);
   await contactsRegistry.execute(subcommand, contactsService, args);
 }

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -242,7 +242,14 @@ function buildMailRegistry(account: string): CommandRegistry<MailService> {
     .register("send", (svc, args) => handleSendMessage(svc, args));
 }
 
-export async function handleMailCommand(subcommand: string, args: string[], account = "default") {
+type MailServiceFactory = (account: string) => MailService;
+
+export async function handleMailCommand(
+  subcommand: string,
+  args: string[],
+  account = "default",
+  serviceFactory: MailServiceFactory = (acc) => new MailService(acc)
+) {
   // Handle help flags before initializing the service (avoids unnecessary auth)
   if (args.includes("--help") || args.includes("-h")) {
     if (subcommand === "send") {
@@ -252,7 +259,7 @@ export async function handleMailCommand(subcommand: string, args: string[], acco
   }
 
   // Create service instance with the specified account
-  const mailService = new MailService(account);
+  const mailService = serviceFactory(account);
 
   // Ensure service is initialized (checks credentials) before any command
   await ensureInitialized(mailService);


### PR DESCRIPTION
## Summary

Resolves the DIP violation in command handlers by accepting an optional `serviceFactory` parameter with a default that preserves current behavior.

## Changes

- Define `MailServiceFactory`, `CalServiceFactory`, `ContactsServiceFactory` type aliases
- Add optional `serviceFactory` parameter to `handleMailCommand`, `handleCalCommand`, `handleContactsCommand`
- Default: `(acc) => new Service(acc)` — identical to current hard-coded behavior
- Handlers use `serviceFactory(account)` instead of `new Service(account)` directly
- No changes to callers in `src/cli.ts`

## Acceptance Criteria Verification

- [x] All three handlers accept optional `serviceFactory` parameter
- [x] Default factory preserves current behavior (callers in `cli.ts` unchanged)
- [x] Service construction uses the factory, not `new` directly
- [x] A test can pass a mock factory without patching module internals
- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun run lint` passes with no errors

Fixes #49