### PR TITLE
refactor(command-error-handler): replace instanceof chain with hint map

### DIFF
--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -4,14 +4,23 @@
  */
 
 export class ServiceError extends Error {
+  /** Optional user-facing hint printed below the error message. */
+  readonly hint?: string;
+  /** Label prefix for the error line (default: "Error:"). */
+  readonly errorLabel: string;
+
   constructor(
     message: string,
     public readonly code: string,
     public readonly httpStatus?: number,
-    public readonly retryable = false
+    public readonly retryable = false,
+    hint?: string,
+    errorLabel = "Error:"
   ) {
     super(message);
     this.name = this.constructor.name;
+    this.hint = hint;
+    this.errorLabel = errorLabel;
     Object.setPrototypeOf(this, ServiceError.prototype);
   }
 }
@@ -34,7 +43,8 @@ export class PermissionDeniedError extends ServiceError {
       `Permission denied: You don't have access to ${resource} ${identifier}`,
       "PERMISSION_DENIED",
       403,
-      false
+      false,
+      "Please check your authentication and permissions."
     );
     Object.setPrototypeOf(this, PermissionDeniedError.prototype);
   }
@@ -42,14 +52,14 @@ export class PermissionDeniedError extends ServiceError {
 
 export class RateLimitError extends ServiceError {
   constructor(message = "Rate limit exceeded") {
-    super(message, "RATE_LIMIT", 429, true);
+    super(message, "RATE_LIMIT", 429, true, "Please wait a moment and try again.");
     Object.setPrototypeOf(this, RateLimitError.prototype);
   }
 }
 
 export class ServiceUnavailableError extends ServiceError {
   constructor(message = "Service temporarily unavailable") {
-    super(message, "SERVICE_UNAVAILABLE", 503, true);
+    super(message, "SERVICE_UNAVAILABLE", 503, true, "The service is temporarily unavailable. Please try again later.");
     Object.setPrototypeOf(this, ServiceUnavailableError.prototype);
   }
 }
@@ -60,7 +70,8 @@ export class InitializationError extends ServiceError {
       `${serviceName} service not initialized`,
       "NOT_INITIALIZED",
       500,
-      false
+      false,
+      "Please run the setup guide to configure your credentials."
     );
     Object.setPrototypeOf(this, InitializationError.prototype);
   }
@@ -68,7 +79,7 @@ export class InitializationError extends ServiceError {
 
 export class ValidationError extends ServiceError {
   constructor(field: string, message: string) {
-    super(`Validation error for ${field}: ${message}`, "VALIDATION_ERROR", 400, false);
+    super(`Validation error for ${field}: ${message}`, "VALIDATION_ERROR", 400, false, undefined, "Validation Error:");
     Object.setPrototypeOf(this, ValidationError.prototype);
   }
 }

--- a/src/utils/command-error-handler.ts
+++ b/src/utils/command-error-handler.ts
@@ -1,14 +1,5 @@
 import chalk from "chalk";
-import {
-  ServiceError,
-  NotFoundError,
-  PermissionDeniedError,
-  RateLimitError,
-  ServiceUnavailableError,
-  InitializationError,
-  ValidationError,
-  ArgumentError,
-} from "../services/errors.ts";
+import { ServiceError } from "../services/errors.ts";
 
 /**
  * Log service errors with appropriate user-friendly messages.
@@ -17,26 +8,11 @@ import {
  * @param error - The error to handle
  */
 export function logServiceError(error: unknown): void {
-  if (error instanceof ArgumentError) {
-    console.error(chalk.red("Error:"), error.message);
-  } else if (error instanceof NotFoundError) {
-    console.error(chalk.red("Error:"), error.message);
-  } else if (error instanceof PermissionDeniedError) {
-    console.error(chalk.red("Error:"), error.message);
-    console.error(chalk.yellow("Please check your authentication and permissions."));
-  } else if (error instanceof RateLimitError) {
-    console.error(chalk.red("Error:"), error.message);
-    console.error(chalk.yellow("Please wait a moment and try again."));
-  } else if (error instanceof ServiceUnavailableError) {
-    console.error(chalk.red("Error:"), error.message);
-    console.error(chalk.yellow("The service is temporarily unavailable. Please try again later."));
-  } else if (error instanceof InitializationError) {
-    console.error(chalk.red("Error:"), error.message);
-    console.error(chalk.yellow("Please run the setup guide to configure your credentials."));
-  } else if (error instanceof ValidationError) {
-    console.error(chalk.red("Validation Error:"), error.message);
-  } else if (error instanceof ServiceError) {
-    console.error(chalk.red("Error:"), error.message);
+  if (error instanceof ServiceError) {
+    console.error(chalk.red(error.errorLabel), error.message);
+    if (error.hint) {
+      console.error(chalk.yellow(error.hint));
+    }
   } else if (error instanceof Error) {
     console.error(chalk.red("Error:"), error.message);
   } else {


### PR DESCRIPTION
## Summary

- Adds `hint?: string` and `errorLabel: string` properties to `ServiceError` base class
- Sets `hint` in `PermissionDeniedError`, `RateLimitError`, `ServiceUnavailableError`, and `InitializationError` constructors
- Sets `errorLabel` to `"Validation Error:"` in `ValidationError` constructor
- Collapses `logServiceError` from a 9-branch `instanceof` chain to 3 branches — same user-visible output, zero subclass coupling

Adding a new `ServiceError` subclass now requires **zero changes** to `command-error-handler.ts`.

Mirrors the pattern established in PR #48 (`HTTP_ERROR_MAP` in `error-handler.ts`).

## Test plan

- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run lint` passes
- [ ] All existing error hint strings produce identical console output
- [ ] `ValidationError` still uses `"Validation Error:"` prefix

Fixes #55