### PR TITLE
refactor(base-service): inject AuthManager via deps parameter

### DIFF
--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -18,6 +18,10 @@ import { TokenStore } from "./token-store.ts";
 import * as path from "path";
 import * as os from "os";
 
+export interface BaseServiceDeps {
+  authManager?: AuthManager;
+}
+
 export abstract class BaseService {
   protected auth: AuthClient | null = null;
   protected readonly SCOPES: string[];
@@ -30,13 +34,13 @@ export abstract class BaseService {
     protected serviceName: string,
     scopes: string[],
     account = "default",
-    logger: Logger = defaultLogger
+    logger: Logger = defaultLogger,
+    deps?: BaseServiceDeps
   ) {
     this.account = account;
     this.SCOPES = scopes;
     this.logger = logger;
-    // Create AuthManager with dependencies
-    this.authManager = new AuthManager({
+    this.authManager = deps?.authManager ?? new AuthManager({
       tokenStore: TokenStore.getInstance(),
       logger: this.logger,
     });


### PR DESCRIPTION
## Summary

- Add `BaseServiceDeps` interface with optional `authManager` field
- Accept `deps?: BaseServiceDeps` as optional constructor parameter
- Fall back to `new AuthManager({ tokenStore, logger })` when not provided
- Mirrors the `ContactsServiceDeps` injection pattern from #53 for testability

## Acceptance Criteria

- [x] `BaseService` accepts optional `AuthManager` via constructor `deps`
- [x] Default behavior unchanged — instantiates `AuthManager` when not provided
- [x] `BaseServiceDeps` interface exported for use in subclass tests
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` passes

Fixes #56