### PR TITLE
fix(sqlite-wrapper): return real changes from bun:sqlite run()

### DIFF
--- a/src/utils/sqlite-wrapper.ts
+++ b/src/utils/sqlite-wrapper.ts
@@ -117,8 +117,11 @@ export class Database {
     return {
       run: (params?: Record<string, any>) => {
         const normalizedParams = this.normalizeBunParams(params);
-        bunStmt.run(normalizedParams);
-        return { changes: 0 }; // Bun doesn't return changes in the same way
+        const result = bunStmt.run(normalizedParams);
+        return {
+          changes: result?.changes ?? 0,
+          lastInsertRowid: result?.lastInsertRowid,
+        };
       },
       get: (params?: Record<string, any>) => {
         const normalizedParams = this.normalizeBunParams(params);


### PR DESCRIPTION
## Summary

- Fix `wrapBunStatement.run()` to capture and return real `{ changes, lastInsertRowid }` from `bunStmt.run()` instead of hardcoding `changes: 0`

## Background

`bun:sqlite` `Statement.run()` returns `{ changes, lastInsertRowid }` but the Bun wrapper discarded the result and always returned `{ changes: 0 }`. This caused `deleteToken()` in `token-store.ts` to always return `false` under Bun runtime (it checks `result.changes > 0`).

## Investigation Notes

Two other bugs listed in the issue were investigated and found not to require fixes:
- **Double-`$` param normalization**: `normalizeBunParams` already correctly guards with `key.startsWith("$") ? key : \`$${key}\`` — no change needed.
- **`PRAGMA busy_timeout` unsupported**: Testing confirmed `PRAGMA busy_timeout` works correctly in `bun:sqlite` 1.3.10. The issue's claim that it required a constructor `timeout` option was incorrect for this bun version.

## Test plan

- [x] `bun test` — 150 tests pass
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run lint` — no lint errors

Fixes #65