### PR TITLE
chore: release v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gwork",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gwork",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gwork",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A CLI tool for managing Google Calendar and Gmail from the command line",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -242,7 +242,7 @@ Examples:
 
 function printVersion() {
   const buildTime = typeof __BUILD_TIME__ !== "undefined" ? ` (built ${__BUILD_TIME__})` : "";
-  console.log(`gwork version 0.3.1${buildTime}`);
+  console.log(`gwork version 0.3.2${buildTime}`);
 }
 
 async function handleMail(args: string[]) {


### PR DESCRIPTION
## Summary
- Bump version from 0.3.1 to 0.3.2
- Update version string in `src/cli.ts`

## Changes since v0.3.1
- fix(deps): add missing `open` package dependency (#75)
- docs(readme): add drive, accounts, and send docs (#74)
- fix(auth): use custom OAuth flow with prompt=consent to fix re-auth loop (#73)
- feat(drive): add Google Drive command with file operations (#71)

## Test plan
- [x] `bun test` — all 162 tests pass
- [x] `bun run build` — succeeds