### PR TITLE
feat(mail): add --from-name option to set sender display name

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -91,6 +91,7 @@ Options:
   --html                  Treat body as HTML
   --attach <path>         Attach a file (repeatable)
   --reply-to <messageId>  Send as a reply to an existing message
+  --from-name <name>      Display name in the From header (e.g. "Alice Smith")
   --account <email>       Use a specific Google account
 
 Examples:
@@ -959,6 +960,7 @@ async function handleSendMessage(mailService: MailService, args: string[]) {
   let bodyFile = "";
   let html = false;
   let replyToMessageId = "";
+  let fromName = "";
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -980,6 +982,8 @@ async function handleSendMessage(mailService: MailService, args: string[]) {
       attachments.push(args[++i]!);
     } else if (arg === "--reply-to" && args[i + 1]) {
       replyToMessageId = args[++i]!;
+    } else if (arg === "--from-name" && args[i + 1]) {
+      fromName = args[++i]!;
     }
   }
 
@@ -1039,6 +1043,7 @@ async function handleSendMessage(mailService: MailService, args: string[]) {
     html,
     attachments: attachments.length > 0 ? attachments : undefined,
     replyToMessageId: replyToMessageId || undefined,
+    fromName: fromName || undefined,
   };
 
   const spinner = ora("Sending message...").start();

--- a/src/services/mail-service.ts
+++ b/src/services/mail-service.ts
@@ -32,17 +32,20 @@ export interface SendMessageOptions {
   html?: boolean;
   attachments?: string[];
   replyToMessageId?: string;
+  fromName?: string;
 }
 
 async function buildMimeMessage(options: SendMessageOptions & {
   inReplyTo?: string;
   references?: string;
   threadId?: string;
+  from?: string;
 }): Promise<{ raw: string; threadId?: string }> {
   // Use nodemailer to build a correctly encoded RFC 2822 message
   const transporter = createTransport({ streamTransport: true, newline: "unix" });
 
   const mailOptions: Parameters<typeof transporter.sendMail>[0] = {
+    ...(options.from ? { from: options.from } : {}),
     to: options.to.join(", "),
     cc: options.cc && options.cc.length > 0 ? options.cc.join(", ") : undefined,
     bcc: options.bcc && options.bcc.length > 0 ? options.bcc.join(", ") : undefined,
@@ -734,12 +737,23 @@ export class MailService extends BaseService {
       }
     }
 
+    // Build the From header when a display name is requested.
+    // users.getProfile only returns emailAddress (no display name), so we always
+    // fetch the address and combine it with the caller-supplied name.
+    let fromHeader: string | undefined;
+    if (options.fromName) {
+      const profile = await this.gmail!.users.getProfile({ userId: "me" });
+      const email = profile.data.emailAddress ?? "";
+      fromHeader = `"${options.fromName}" <${email}>`;
+    }
+
     try {
       const { raw, threadId: tid } = await buildMimeMessage({
         ...options,
         inReplyTo,
         references,
         threadId,
+        from: fromHeader,
       });
 
       const requestBody: gmail_v1.Schema$Message = { raw };


### PR DESCRIPTION
## Summary

- Adds `--from-name <name>` flag to `gwork mail send` so the `From:` header is set as `"Name" <email@example.com>` instead of a bare address
- Fetches the authenticated account's email via `users.getProfile` and combines it with the caller-supplied display name
- Updates `SendMessageOptions` interface with new `fromName?: string` field and threads it through `buildMimeMessage` → nodemailer

## Test plan

- [ ] `bun test` passes (162 tests)
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run lint` clean
- [ ] Manual: `gwork mail send --to x@example.com --subject test --body hi --from-name "Alice"` produces `From: "Alice" <sender@example.com>`
- [ ] Manual: sending without `--from-name` still works (From is set by Gmail from the auth token as before)

Fixes #80