### PR TITLE
fix(mail): resolve 'Invalid attachment token' for inline MIME attachments

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -624,14 +624,27 @@ async function listDrafts(mailService: MailService, args: string[]) {
   await listMessages(mailService, [...args, "--label", "DRAFT"]);
 }
 
+/** Recursively collects all MIME parts from a nested multipart tree. */
+function flattenParts(parts: any[]): any[] {
+  const result: any[] = [];
+  for (const part of parts) {
+    result.push(part);
+    if (part.parts && part.parts.length > 0) {
+      result.push(...flattenParts(part.parts));
+    }
+  }
+  return result;
+}
+
 async function listAttachments(mailService: MailService, messageId: string) {
   const spinner = ora("Fetching attachments...").start();
   try {
     const message = await mailService.getMessage(messageId, "full");
     spinner.succeed("Attachments fetched");
 
-    const parts = message.payload?.parts || [];
-    const attachments = parts.filter((p: any) => p.filename && p.body?.attachmentId);
+    const allParts = flattenParts(message.payload?.parts || []);
+    // Include parts with a filename whether data is inline (body.data) or external (body.attachmentId)
+    const attachments = allParts.filter((p: any) => p.filename && (p.body?.attachmentId || p.body?.data));
 
     if (attachments.length === 0) {
       logger.info(chalk.yellow("No attachments found"));
@@ -646,7 +659,9 @@ async function listAttachments(mailService: MailService, messageId: string) {
       logger.info(`\n${chalk.bold(`${index + 1}.`)} ${chalk.cyan(part.filename)}`);
       logger.info(`   ${chalk.gray("Type:")} ${part.mimeType}`);
       logger.info(`   ${chalk.gray("Size:")} ${sizeMB} MB`);
-      logger.info(`   ${chalk.gray("Attachment ID:")} ${part.body.attachmentId}`);
+      if (part.body?.attachmentId) {
+        logger.info(`   ${chalk.gray("Attachment ID:")} ${part.body.attachmentId}`);
+      }
     });
   } catch (error: unknown) {
     spinner.fail("Failed to fetch attachments");
@@ -657,22 +672,28 @@ async function listAttachments(mailService: MailService, messageId: string) {
 async function downloadAttachment(mailService: MailService, messageId: string, attachmentId: string, filename?: string) {
   const spinner = ora("Downloading attachment...").start();
   try {
-    const attachment = await mailService.getAttachment(messageId, attachmentId);
-    const data = Buffer.from(attachment.data || "", "base64");
+    // Fetch the full message first to check for inline body.data.
+    // Some senders (e.g. GCP billing) attach PDFs as inline MIME parts: Gmail assigns
+    // an attachmentId but stores the data directly in body.data. Calling attachments.get
+    // on such parts fails with "Invalid attachment token". Reading body.data avoids the
+    // extra round-trip and handles that case.
+    const message = await mailService.getMessage(messageId, "full");
+    const allParts = flattenParts(message.payload?.parts || []);
+    const matchingPart = allParts.find((p: any) => p.body?.attachmentId === attachmentId);
+
+    let data: Buffer;
+    if (matchingPart?.body?.data) {
+      // Inline attachment — data already present in the full message response
+      data = Buffer.from(matchingPart.body.data, "base64");
+    } else {
+      // External attachment — fetch via the attachments API
+      const attachment = await mailService.getAttachment(messageId, attachmentId);
+      data = Buffer.from(attachment.data || "", "base64");
+    }
 
     let outputFile = filename;
-    if (!outputFile) {
-      // Try to find the original filename from the message's attachment metadata
-      try {
-        const message = await mailService.getMessage(messageId, "full");
-        const parts = message.payload?.parts || [];
-        const matchingPart = parts.find((p: any) => p.body?.attachmentId === attachmentId);
-        if (matchingPart?.filename && matchingPart.filename.length > 0) {
-          outputFile = matchingPart.filename;
-        }
-      } catch {
-        // Metadata fetch failed — fall through to hash-based fallback
-      }
+    if (!outputFile && matchingPart?.filename && matchingPart.filename.length > 0) {
+      outputFile = matchingPart.filename;
     }
     if (!outputFile) {
       // Fall back to a short, safe hash of the attachment ID


### PR DESCRIPTION
## Summary

- Fixes `gwork mail download` failing with `Error: Failed to get attachment: Invalid attachment token` for GCP billing emails and similar senders
- Adds recursive MIME part traversal (`flattenParts`) so attachments nested in `multipart/related` / `multipart/mixed` sub-trees are correctly found

## Root Cause

GCP billing emails (and some other automated senders) attach PDFs as **inline MIME parts**: Gmail assigns an `attachmentId` in the message metadata but stores the actual data in `body.data` of that part. Calling `users.messages.attachments.get` on such parts fails with "Invalid attachment token" because there is no separately-stored binary blob in Gmail's attachment storage.

## Fix

In `downloadAttachment`: always fetch the full message first (`getMessage format=full`), locate the matching part via the new `flattenParts()` recursive helper, and read `body.data` when present. Only call the `attachments.get` API when `body.data` is absent (i.e., for large externally-stored blobs that exceed Gmail's inline threshold).

In `listAttachments`: use the same `flattenParts()` helper so nested attachment parts are listed, and show parts with either `body.attachmentId` or inline `body.data`.

## Test plan

- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run lint` clean
- [ ] `bun test` 162/162 pass
- [ ] Manual: `gwork mail download <gcp-msg-id> <att-id>` downloads invoice PDF successfully
- [ ] Manual: `gwork mail download <normal-att-id>` still works for standard large attachments (Vercel, Cloudflare, etc.)
- [ ] Manual: `gwork mail attachments <gcp-msg-id>` lists the PDF attachment

Fixes #81