### PR TITLE
refactor: extract SEPARATOR constant and printSectionHeader utility

### DIFF
--- a/src/commands/accounts.ts
+++ b/src/commands/accounts.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import { TokenStore } from "../services/token-store.ts";
 import { groupBy } from "lodash-es";
 import { logger } from "../utils/logger.ts";
+import { printSectionHeader } from "../utils/output.ts";
 
 /**
  * Formats time remaining until token expiry.
@@ -51,8 +52,7 @@ export async function handleAccountsCommand(args: string[]) {
     // Group tokens by account email
     const accounts = groupBy(tokens, "account");
 
-    logger.info(chalk.bold("\nConfigured Accounts:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nConfigured Accounts:");
 
     Object.entries(accounts).forEach(([email, accountTokens], index) => {
       logger.info(`\n${chalk.bold(`${index + 1}.`)} ${chalk.cyan(email)}`);

--- a/src/commands/cal.ts
+++ b/src/commands/cal.ts
@@ -8,6 +8,7 @@ import { ArgumentError } from "../services/errors.ts";
 import { formatEventDate, parseDateRange } from "../utils/format.ts";
 import { ensureInitialized } from "../utils/command-service.ts";
 import { logger } from "../utils/logger.ts";
+import { printSectionHeader } from "../utils/output.ts";
 import { CommandRegistry } from "./registry.ts";
 
 const calRegistry = new CommandRegistry<CalendarService>()
@@ -315,8 +316,7 @@ async function listEvents(calendarService: CalendarService, args: string[]) {
     if (options.format === "json") {
       logger.info(JSON.stringify(events, null, 2));
     } else {
-      logger.info(chalk.bold("\nEvents:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nEvents:");
       events.forEach((event: Event, index: number) => {
         const start = event.start?.dateTime ?? event.start?.date;
         const end = event.end?.dateTime ?? event.end?.date;
@@ -386,8 +386,7 @@ async function listCalendars(calendarService: CalendarService, args: string[]) {
     if (options.format === "json") {
       logger.info(JSON.stringify(calendars, null, 2));
     } else {
-      logger.info(chalk.bold("\nCalendars:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nCalendars:");
       calendars.forEach((calendar: calendar_v3.Schema$CalendarListEntry) => {
         const accessRole = calendar.accessRole || "unknown";
         const color =
@@ -422,8 +421,7 @@ async function getEvent(calendarService: CalendarService, calendarId: string, ev
     const event = await calendarService.getEvent(calendarId, eventId);
     spinner.succeed("Event details fetched");
 
-    logger.info(chalk.bold("\nEvent Details:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nEvent Details:");
     logger.info(`${chalk.cyan("Title:")} ${event.summary || "No title"}`);
     logger.info(`${chalk.cyan("ID:")} ${event.id}`);
     logger.info(
@@ -718,8 +716,7 @@ async function searchEvents(calendarService: CalendarService, query: string, ext
       return;
     }
 
-    logger.info(chalk.bold(`\nSearch results for: "${query}"`));
-    logger.info("─".repeat(80));
+    printSectionHeader(`\nSearch results for: "${query}"`);
     events.forEach((event: Event, index: number) => {
       const start = event.start?.dateTime ?? event.start?.date;
       const summary = event.summary || "No title";
@@ -759,8 +756,7 @@ async function getFreeBusy(calendarService: CalendarService, start: string, end:
     );
     spinner.succeed("Free/busy information fetched");
 
-    logger.info(chalk.bold("\nFree/Busy Information:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nFree/Busy Information:");
     logger.info(
       `${chalk.cyan("Time Range:")} ${startTime.toISOString()} to ${endTime.toISOString()}`
     );
@@ -889,8 +885,7 @@ async function getStats(calendarService: CalendarService, args: string[]) {
       (stats.totalDuration % (1000 * 60 * 60)) / (1000 * 60)
     );
 
-    logger.info(chalk.bold("\nCalendar Statistics:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nCalendar Statistics:");
     logger.info(`${chalk.cyan("Total Events:")} ${stats.total}`);
     logger.info(`${chalk.cyan("All-day Events:")} ${stats.allDay}`);
     logger.info(`${chalk.cyan("Timed Events:")} ${stats.timed}`);
@@ -1217,8 +1212,7 @@ async function manageReminders(
       const reminders = event.reminders?.overrides || [];
       const useDefault = event.reminders?.useDefault || false;
 
-      logger.info(chalk.bold("\nEvent Reminders:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nEvent Reminders:");
       if (useDefault) {
         logger.info(chalk.cyan("Using default reminders"));
       }
@@ -1593,8 +1587,7 @@ async function checkConflict(calendarService: CalendarService, calendarId: strin
 
     spinner.succeed("Conflict check complete");
 
-    logger.info(chalk.bold("\nConflict Check:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nConflict Check:");
     logger.info(
       `${chalk.cyan("Time Range:")} ${startTime.toLocaleString()} to ${endTime.toLocaleString()}`
     );
@@ -1724,8 +1717,7 @@ async function compareCalendars(calendarService: CalendarService, calendarId1: s
         )
       );
     } else {
-      logger.info(chalk.bold("\nCalendar Comparison:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nCalendar Comparison:");
       logger.info(`${chalk.cyan("Calendar 1:")} ${calendarId1} - ${events1.length} events`);
       logger.info(`${chalk.cyan("Calendar 2:")} ${calendarId2} - ${events2.length} events`);
       logger.info(`${chalk.cyan("Overlapping:")} ${overlapping.length} events`);
@@ -1882,8 +1874,7 @@ async function manageColor(calendarService: CalendarService, args: string[]) {
 
     if (args.length === 0 || args[0] === "list") {
       spinner.succeed("Available colors:");
-      logger.info(chalk.bold("\nGoogle Calendar Colors:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nGoogle Calendar Colors:");
       Object.entries(colorMap).forEach(([id, name]) => {
         const nameStr = typeof name === "string" ? name : String(name);
         logger.info(`  ${id.toString().padStart(2)}. ${startCase(nameStr)}`);
@@ -1930,8 +1921,7 @@ async function workWithRecurrence(args: string[]) {
   const spinner = ora("Working with recurrence...").start();
   try {
     if (args.length === 0 || args[0] === "help") {
-      logger.info(chalk.bold("\nRecurrence Utilities:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nRecurrence Utilities:");
       logger.info("Parse RRULE: gwork cal recurrence parse <rrule>");
       logger.info("Show occurrences: gwork cal recurrence occurrences <rrule> [--count N]");
       return;
@@ -2134,8 +2124,7 @@ async function showRecurrenceInfo(calendarService: CalendarService, calendarId: 
 
     spinner.succeed("Recurrence info fetched");
 
-    logger.info(chalk.bold("\nRecurrence Information:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nRecurrence Information:");
     logger.info(`${chalk.cyan("Event:")} ${event.summary || "No title"}`);
     logger.info(`${chalk.cyan("RRULE:")} ${rruleString}`);
     logger.info(`${chalk.cyan("Natural language:")} ${text}`);
@@ -2156,8 +2145,7 @@ async function showRecurrenceInfo(calendarService: CalendarService, calendarId: 
 
 async function dateUtilities(args: string[]) {
   if (args.length === 0 || args[0] === "help") {
-    logger.info(chalk.bold("\nDate Utilities:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nDate Utilities:");
     logger.info("Format: gwork cal date format <date> [--format <format>]");
     logger.info("Parse: gwork cal date parse <dateString>");
     logger.info("Add: gwork cal date add <date> <amount> <unit>");

--- a/src/commands/contacts.ts
+++ b/src/commands/contacts.ts
@@ -5,6 +5,8 @@ import { ContactsService } from "../services/contacts-service.ts";
 import { ensureInitialized } from "../utils/command-service.ts";
 import { ArgumentError } from "../services/errors.ts";
 import { logger } from "../utils/logger.ts";
+import { SEPARATOR } from "../utils/format.ts";
+import { printSectionHeader } from "../utils/output.ts";
 import { CommandRegistry } from "./registry.ts";
 
 const contactsRegistry = new CommandRegistry<ContactsService>()
@@ -153,8 +155,7 @@ async function listContacts(contactsService: ContactsService, args: string[]) {
     if (options.format === "json") {
       logger.info(JSON.stringify(contacts, null, 2));
     } else {
-      logger.info(chalk.bold("\nContacts:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nContacts:");
       contacts.forEach((contact: Person, index: number) => {
         const name = contact.names?.[0]?.displayName || "No name";
         const email = contact.emailAddresses?.[0]?.value || "";
@@ -198,8 +199,7 @@ async function getContact(contactsService: ContactsService, resourceName: string
     if (options.format === "json") {
       logger.info(JSON.stringify(contact, null, 2));
     } else {
-      logger.info(chalk.bold("\nContact Details:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nContact Details:");
 
       const name = contact.names?.[0]?.displayName || "No name";
       logger.info(`${chalk.cyan("Name:")} ${name}`);
@@ -281,8 +281,7 @@ async function searchContacts(contactsService: ContactsService, query: string, a
     if (options.format === "json") {
       logger.info(JSON.stringify(contacts, null, 2));
     } else {
-      logger.info(chalk.bold(`\nSearch Results for "${query}":`));
-      logger.info("─".repeat(80));
+      printSectionHeader(`\nSearch Results for "${query}":`);
       contacts.forEach((contact: Person, index: number) => {
         const name = contact.names?.[0]?.displayName || "No name";
         const email = contact.emailAddresses?.[0]?.value || "";
@@ -311,8 +310,7 @@ async function findContactByEmail(contactsService: ContactsService, email: strin
 
     spinner.succeed("Contact found");
 
-    logger.info(chalk.bold("\nContact Found:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nContact Found:");
 
     const name = contact.names?.[0]?.displayName || "No name";
     logger.info(`${chalk.cyan("Name:")} ${name}`);
@@ -345,8 +343,7 @@ async function findContactByName(contactsService: ContactsService, name: string)
 
     spinner.succeed("Contact found");
 
-    logger.info(chalk.bold("\nContact Found:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nContact Found:");
 
     const displayName = contact.names?.[0]?.displayName || "No name";
     logger.info(`${chalk.cyan("Name:")} ${displayName}`);
@@ -423,7 +420,7 @@ async function createContact(contactsService: ContactsService, args: string[]) {
     spinner.succeed("Contact created successfully");
 
     logger.info(chalk.green("\nCreated Contact:"));
-    logger.info("─".repeat(80));
+    logger.info(SEPARATOR);
     const name = contact.names?.[0]?.displayName || "No name";
     logger.info(`${chalk.cyan("Name:")} ${name}`);
     logger.info(`${chalk.cyan("Resource Name:")} ${contact.resourceName}`);
@@ -483,7 +480,7 @@ async function updateContact(contactsService: ContactsService, resourceName: str
     spinner.succeed("Contact updated successfully");
 
     logger.info(chalk.green("\nUpdated Contact:"));
-    logger.info("─".repeat(80));
+    logger.info(SEPARATOR);
     const name = contact.names?.[0]?.displayName || "No name";
     logger.info(`${chalk.cyan("Name:")} ${name}`);
     logger.info(`${chalk.cyan("Resource Name:")} ${contact.resourceName}`);
@@ -543,8 +540,7 @@ async function listGroups(contactsService: ContactsService, args: string[]) {
     if (options.format === "json") {
       logger.info(JSON.stringify(groups, null, 2));
     } else {
-      logger.info(chalk.bold("\nContact Groups:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nContact Groups:");
       groups.forEach((group: ContactGroup, index: number) => {
         const name = group.name || "No name";
         const memberCount = (group.memberCount || 0).toString();
@@ -575,8 +571,7 @@ async function createGroup(contactsService: ContactsService, name: string, args:
 
     spinner.succeed("Contact group created successfully");
 
-    logger.info(chalk.bold("\nCreated Group:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nCreated Group:");
     logger.info(`${chalk.cyan("Name:")} ${group.name}`);
     logger.info(`${chalk.cyan("Resource Name:")} ${group.resourceName}`);
 
@@ -620,8 +615,7 @@ async function getContactsInGroup(contactsService: ContactsService, groupResourc
       process.exit(0);
     }
 
-    logger.info(chalk.bold("\nContacts in Group:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nContacts in Group:");
     result.contacts.forEach((contact: Person, index: number) => {
       const name = contact.names?.[0]?.displayName || "No name";
       const email = contact.emailAddresses?.[0]?.value || "";
@@ -704,8 +698,7 @@ async function batchCreateContacts(contactsService: ContactsService, jsonFile: s
     }
 
     if (created.length > 0) {
-      logger.info(chalk.bold("\nCreated Contacts:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nCreated Contacts:");
       created.forEach((contact) => {
         const name = contact.names?.[0]?.displayName || "No name";
         logger.info(chalk.cyan(name));
@@ -713,8 +706,7 @@ async function batchCreateContacts(contactsService: ContactsService, jsonFile: s
     }
 
     if (failures.length > 0) {
-      logger.info(chalk.bold("\nFailed Contacts:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nFailed Contacts:");
       failures.forEach(({ index, data, error }) => {
         const name = data.firstName || data.lastName || `index ${index}`;
         const msg = error instanceof Error ? error.message : String(error);
@@ -774,8 +766,7 @@ async function getProfile(contactsService: ContactsService, args: string[]) {
     if (options.format === "json") {
       logger.info(JSON.stringify(profile, null, 2));
     } else {
-      logger.info(chalk.bold("\nYour Profile:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nYour Profile:");
 
       const name = profile.names?.[0]?.displayName || "No name";
       logger.info(`${chalk.cyan("Name:")} ${name}`);
@@ -821,8 +812,7 @@ async function getStats(contactsService: ContactsService, _args: string[]) {
       contactsWithPhotos: contacts.filter((c) => c.photos && c.photos.length > 0).length,
     };
 
-    logger.info(chalk.bold("\nContact Statistics:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nContact Statistics:");
     logger.info(`${chalk.cyan("Total Contacts:")} ${stats.totalContacts}`);
     logger.info(`${chalk.cyan("Total Groups:")} ${stats.totalGroups}`);
     logger.info(`${chalk.cyan("Contacts with Email:")} ${stats.contactsWithEmails}`);
@@ -853,8 +843,7 @@ async function mergeContacts(contactsService: ContactsService, targetResourceNam
 
     spinner.succeed("Contacts merged successfully");
 
-    logger.info(chalk.bold("\nMerge Results:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nMerge Results:");
     const mergedName = result.mergedContact.names?.[0]?.displayName || "No name";
     logger.info(`${chalk.cyan("Target Contact:")} ${mergedName}`);
     logger.info(`${chalk.cyan("Resource Name:")} ${result.mergedContact.resourceName}`);
@@ -924,8 +913,7 @@ async function autoMergeContacts(contactsService: ContactsService, args: string[
         `Found ${result.mergeOperations} merge operations in duplicates`
       );
 
-      logger.info(chalk.bold("\nAuto-Merge Preview:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nAuto-Merge Preview:");
       logger.info(`${chalk.cyan("Merge Operations:")} ${result.mergeOperations}`);
 
       if (result.mergeOperations === 0) {
@@ -940,8 +928,7 @@ async function autoMergeContacts(contactsService: ContactsService, args: string[
     } else {
       spinner.succeed(`Executed ${result.mergeOperations} merge operations`);
 
-      logger.info(chalk.bold("\nAuto-Merge Results:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nAuto-Merge Results:");
       logger.info(`${chalk.cyan("Merge Operations:")} ${result.mergeOperations}`);
 
       if (result.results) {
@@ -1026,8 +1013,7 @@ async function findDuplicates(contactsService: ContactsService, args: string[]) 
       logger.info(JSON.stringify(result, null, 2));
     } else if (options.showDetails) {
       // Detailed format
-      logger.info(chalk.bold("\nDuplicate Analysis:"));
-      logger.info("─".repeat(80));
+      printSectionHeader("\nDuplicate Analysis:");
       logger.info(`${chalk.cyan("Total Contacts Analyzed:")} ${result.totalContacts}`);
       logger.info(`${chalk.cyan("Duplicate Groups Found:")} ${result.totalDuplicates}`);
       logger.info("");
@@ -1409,8 +1395,7 @@ async function detectMarketing(contactsService: ContactsService, args: string[])
 
           cleanupSpinner.succeed("Cleanup completed");
 
-          logger.info(chalk.bold("\nCleanup Results:"));
-          logger.info("─".repeat(80));
+          printSectionHeader("\nCleanup Results:");
           logger.info(
             `${chalk.green("Deleted:")} ${cleanupResult.deleted}/${result.marketingContacts}`
           );

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -6,6 +6,8 @@ import type { SendMessageOptions } from "../services/mail-service.ts";
 import { ensureInitialized } from "../utils/command-service.ts";
 import { ArgumentError } from "../services/errors.ts";
 import { logger } from "../utils/logger.ts";
+import { SEPARATOR } from "../utils/format.ts";
+import { printSectionHeader } from "../utils/output.ts";
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import { CommandRegistry } from "./registry.ts";
@@ -279,8 +281,7 @@ async function listLabels(mailService: MailService, _args: string[]) {
       return;
     }
 
-    logger.info(chalk.bold("\nGmail Labels:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nGmail Labels:");
     labels.forEach((label: any) => {
       const name = label.name || "Unknown";
       const type = label.type || "user";
@@ -342,8 +343,7 @@ async function listMessages(mailService: MailService, args: string[]) {
     );
     const messages = await Promise.all(messagePromises);
 
-    logger.info(chalk.bold("\nMessages:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nMessages:");
     messages.forEach((message, index: number) => {
       const headers = message.payload?.headers || [];
       const from = getHeader(headers, "from");
@@ -389,8 +389,7 @@ async function getMessage(mailService: MailService, messageId: string, args: str
     const message = await mailService.getMessage(messageId, "full");
     spinner.succeed("Message fetched");
 
-    logger.info(chalk.bold("\nMessage:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nMessage:");
     logger.info(formatMessage(message, format));
 
     const parts = message.payload?.parts || [];
@@ -456,8 +455,7 @@ async function searchMessages(mailService: MailService, query: string, extraArgs
       return;
     }
 
-    logger.info(chalk.bold(`\nSearch Results for: "${query}"`));
-    logger.info("─".repeat(80));
+    printSectionHeader(`\nSearch Results for: "${query}"`);
     messages.forEach((message, index: number) => {
       const headers = message.payload?.headers || [];
       const from = getHeader(headers, "from");
@@ -487,8 +485,7 @@ async function getStats(mailService: MailService) {
 
     spinner.succeed("Statistics fetched");
 
-    logger.info(chalk.bold("\nGmail Statistics:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nGmail Statistics:");
     logger.info(`${chalk.cyan("Email Address:")} ${profile.emailAddress}`);
     logger.info(`${chalk.cyan("Total Messages:")} ${totalCount}`);
     logger.info(`${chalk.cyan("Unread Messages:")} ${unreadCount}`);
@@ -535,8 +532,7 @@ async function listThreads(mailService: MailService, args: string[]) {
       return;
     }
 
-    logger.info(chalk.bold("\nThreads:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nThreads:");
     result.threads.forEach((thread: any, index: number) => {
       logger.info(`\n${chalk.bold(`${index + 1}.`)} ${chalk.cyan("Thread ID:")} ${thread.id}`);
       logger.info(`   ${chalk.gray("Messages:")} ${thread.messages?.length || 0}`);
@@ -573,15 +569,14 @@ async function getThread(mailService: MailService, threadId: string, args: strin
     const thread = await mailService.getThread(threadId);
     spinner.succeed("Thread fetched");
 
-    logger.info(chalk.bold("\nThread:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nThread:");
     logger.info(`${chalk.cyan("Thread ID:")} ${thread.id}`);
     logger.info(`${chalk.cyan("Messages:")} ${thread.messages?.length || 0}`);
 
     if (thread.messages && thread.messages.length > 0) {
       thread.messages.forEach((message: any, index: number) => {
         logger.info(`\n${chalk.bold(`Message ${index + 1}:`)}`);
-        logger.info("─".repeat(80));
+        logger.info(SEPARATOR);
 
         if (showFullMessages) {
           // Show full message with body
@@ -651,8 +646,7 @@ async function listAttachments(mailService: MailService, messageId: string) {
       return;
     }
 
-    logger.info(chalk.bold("\nAttachments:"));
-    logger.info("─".repeat(80));
+    printSectionHeader("\nAttachments:");
     attachments.forEach((part: any, index: number) => {
       const size = part.body?.size || 0;
       const sizeMB = (size / 1024 / 1024).toFixed(2);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,6 @@
+/** Horizontal rule used throughout CLI output sections. */
+export const SEPARATOR = "─".repeat(80);
+
 import {
   format,
   parseISO,

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,0 +1,16 @@
+import chalk from "chalk";
+import { logger } from "./logger.ts";
+import { SEPARATOR } from "./format.ts";
+
+/**
+ * Print a bold section header followed by a horizontal separator.
+ * Used consistently across all CLI command output sections.
+ *
+ * @example
+ * printSectionHeader("\nMessages:");
+ * // outputs: bold "\nMessages:" then "────────────────────..."
+ */
+export function printSectionHeader(title: string): void {
+  logger.info(chalk.bold(title));
+  logger.info(SEPARATOR);
+}


### PR DESCRIPTION
## Summary

- Extracts the `"─".repeat(80)` string (42 occurrences) into a shared `SEPARATOR` constant in `src/utils/format.ts`
- Creates `src/utils/output.ts` with a `printSectionHeader(title)` helper that encapsulates the repeated bold-title + separator pattern (~35 occurrences across command files)
- Updates all four command files (`mail.ts`, `cal.ts`, `contacts.ts`, `accounts.ts`) to import and use both utilities

## Test plan

- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run lint` — no lint warnings
- [x] `bun test` — 172 tests pass, 0 failures