### PR TITLE
fix(tests): apply lint auto-fixes to mail and registry test files

### DIFF
--- a/tests/unit/commands/mail.test.ts
+++ b/tests/unit/commands/mail.test.ts
@@ -62,7 +62,7 @@ function makeStatsFactory(throwOnFirst: boolean) {
 
 describe("handleMailCommand re-auth retry", () => {
   let originalGetInstance: typeof TokenStore.getInstance;
-  let deleteTokenCalls: Array<[string, string]>;
+  let deleteTokenCalls: [string, string][];
   let consoleLogSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {

--- a/tests/unit/commands/registry.test.ts
+++ b/tests/unit/commands/registry.test.ts
@@ -15,10 +15,10 @@ import { ArgumentError } from "../../../src/services/errors.ts";
 // Helpers
 // ---------------------------------------------------------------------------
 
-type StubService = { name: string };
+interface StubService { name: string }
 
 function makeRegistry() {
-  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const calls: { cmd: string; args: string[] }[] = [];
   const registry = new CommandRegistry<StubService>()
     .register("foo", async (_svc, args) => { calls.push({ cmd: "foo", args }); })
     .register("bar", async (_svc, args) => { calls.push({ cmd: "bar", args }); });


### PR DESCRIPTION
## Summary

- Replace `Array<T>` with `T[]` in mail and registry test files
- Replace `type` with `interface` where applicable

These lint fixes were applied by `bun run lint:fix` during the error-handling PR (#89) session but were not committed before that PR merged. This brings `main` to a fully lint-clean state.

## Test plan
- [ ] `bun run lint` passes (no errors)
- [ ] `bun test` passes (255 tests)