### PR TITLE
refactor(commands): replace duplicate fatalExit with shared handleServiceError

### DIFF
--- a/src/commands/cal.ts
+++ b/src/commands/cal.ts
@@ -9,7 +9,7 @@ import { formatEventDate, parseDateRange } from "../utils/format.ts";
 import { ensureInitialized } from "../utils/command-service.ts";
 import { retryWithBackoff } from "../utils/retry-helper.ts";
 import { logger } from "../utils/logger.ts";
-import { logServiceError } from "../utils/command-error-handler.ts";
+import { handleServiceError } from "../utils/command-error-handler.ts";
 import { printSectionHeader } from "../utils/output.ts";
 import { CommandRegistry } from "./registry.ts";
 
@@ -145,12 +145,6 @@ const calRegistry = new CommandRegistry<CalendarService>()
 
 type CalServiceFactory = (account: string) => CalendarService;
 
-/** Log a terminal service error and exit non-zero. Never returns. */
-function fatalExit(error: unknown): never {
-  logServiceError(error);
-  process.exit(1);
-}
-
 /**
  * Delete the stale token, build a fresh service, and execute the command
  * exactly once. Any failure in the retry is fatal — no further re-auth loops.
@@ -170,7 +164,7 @@ async function reAuthAndRetry(
   try {
     await calRegistry.execute(subcommand, freshService, args);
   } catch (retryError) {
-    fatalExit(retryError);
+    handleServiceError(retryError);
   }
 }
 
@@ -196,7 +190,7 @@ export async function handleCalCommand(
     } else if (error instanceof AuthenticationRequiredError) {
       await reAuthAndRetry("calendar", account, error.hint ?? "Re-authenticating with Calendar...", serviceFactory, subcommand, args);
     } else {
-      fatalExit(error);
+      handleServiceError(error);
     }
   }
 }

--- a/src/commands/contacts.ts
+++ b/src/commands/contacts.ts
@@ -7,7 +7,7 @@ import { retryWithBackoff } from "../utils/retry-helper.ts";
 import { ArgumentError, ScopeInsufficientError, AuthenticationRequiredError } from "../services/errors.ts";
 import { TokenStore } from "../services/token-store.ts";
 import { logger } from "../utils/logger.ts";
-import { logServiceError } from "../utils/command-error-handler.ts";
+import { handleServiceError } from "../utils/command-error-handler.ts";
 import { SEPARATOR } from "../utils/format.ts";
 import { printSectionHeader } from "../utils/output.ts";
 import { CommandRegistry } from "./registry.ts";
@@ -111,12 +111,6 @@ const contactsRegistry = new CommandRegistry<ContactsService>()
 
 type ContactsServiceFactory = (account: string) => ContactsService;
 
-/** Log a terminal service error and exit non-zero. Never returns. */
-function fatalExit(error: unknown): never {
-  logServiceError(error);
-  process.exit(1);
-}
-
 /**
  * Delete the stale token, build a fresh service, and execute the command
  * exactly once. Any failure in the retry is fatal — no further re-auth loops.
@@ -136,7 +130,7 @@ async function reAuthAndRetry(
   try {
     await contactsRegistry.execute(subcommand, freshService, args);
   } catch (retryError) {
-    fatalExit(retryError);
+    handleServiceError(retryError);
   }
 }
 
@@ -162,7 +156,7 @@ export async function handleContactsCommand(
     } else if (error instanceof AuthenticationRequiredError) {
       await reAuthAndRetry("contacts", account, error.hint ?? "Re-authenticating with Contacts...", serviceFactory, subcommand, args);
     } else {
-      fatalExit(error);
+      handleServiceError(error);
     }
   }
 }

--- a/src/commands/drive.ts
+++ b/src/commands/drive.ts
@@ -5,7 +5,7 @@ import { ensureInitialized } from "../utils/command-service.ts";
 import { retryWithBackoff } from "../utils/retry-helper.ts";
 import { ArgumentError, ScopeInsufficientError, AuthenticationRequiredError } from "../services/errors.ts";
 import { logger } from "../utils/logger.ts";
-import { logServiceError } from "../utils/command-error-handler.ts";
+import { handleServiceError } from "../utils/command-error-handler.ts";
 import { TokenStore } from "../services/token-store.ts";
 import { CommandRegistry } from "./registry.ts";
 import type { ListFilesOptions } from "../services/drive-service.ts";
@@ -268,11 +268,6 @@ function buildDriveRegistry(): CommandRegistry<DriveService> {
 
 type DriveServiceFactory = (account: string) => DriveService;
 
-function fatalExit(error: unknown): never {
-  logServiceError(error);
-  process.exit(1);
-}
-
 async function reAuthAndRetry(
   tokenKey: string,
   account: string,
@@ -288,7 +283,7 @@ async function reAuthAndRetry(
   try {
     await buildDriveRegistry().execute(subcommand, freshService, args);
   } catch (retryError) {
-    fatalExit(retryError);
+    handleServiceError(retryError);
   }
 }
 
@@ -313,7 +308,7 @@ export async function handleDriveCommand(
     } else if (error instanceof AuthenticationRequiredError) {
       await reAuthAndRetry("drive", account, error.hint ?? "Re-authenticating with Drive...", serviceFactory, subcommand, args);
     } else {
-      fatalExit(error);
+      handleServiceError(error);
     }
   }
 }

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -7,7 +7,7 @@ import { retryWithBackoff } from "../utils/retry-helper.ts";
 import { ArgumentError, ScopeInsufficientError, AuthenticationRequiredError } from "../services/errors.ts";
 import { TokenStore } from "../services/token-store.ts";
 import { logger } from "../utils/logger.ts";
-import { logServiceError } from "../utils/command-error-handler.ts";
+import { handleServiceError } from "../utils/command-error-handler.ts";
 import { SEPARATOR } from "../utils/format.ts";
 import { printSectionHeader } from "../utils/output.ts";
 import fs from "node:fs";
@@ -249,12 +249,6 @@ function buildMailRegistry(account: string): CommandRegistry<MailService> {
 
 type MailServiceFactory = (account: string) => MailService;
 
-/** Log a terminal service error and exit non-zero. Never returns. */
-function fatalExit(error: unknown): never {
-  logServiceError(error);
-  process.exit(1);
-}
-
 /**
  * Delete the stale token, build a fresh service, and execute the command
  * exactly once. Any failure in the retry is fatal — no further re-auth loops.
@@ -274,7 +268,7 @@ async function reAuthAndRetry(
   try {
     await buildMailRegistry(account).execute(subcommand, freshService, args);
   } catch (retryError) {
-    fatalExit(retryError);
+    handleServiceError(retryError);
   }
 }
 
@@ -311,7 +305,7 @@ export async function handleMailCommand(
       // All other errors (rate-limit, service-unavailable, any future
       // ServiceError subclass, or unexpected JS errors) are routed through
       // a single fatal log-and-exit so no error is ever double-logged.
-      fatalExit(error);
+      handleServiceError(error);
     }
   }
 }

--- a/tests/unit/commands/cal.test.ts
+++ b/tests/unit/commands/cal.test.ts
@@ -24,6 +24,11 @@ void mock.module("ora", () => ({
 const logServiceErrorCalls: unknown[] = [];
 void mock.module("../../../src/utils/command-error-handler.ts", () => ({
   logServiceError: (err: unknown) => { logServiceErrorCalls.push(err); },
+  handleServiceError: (err: unknown): never => {
+    logServiceErrorCalls.push(err);
+    process.exit(1);
+    return undefined as never;
+  },
 }));
 
 import { handleCalCommand } from "../../../src/commands/cal.ts";

--- a/tests/unit/commands/contacts.test.ts
+++ b/tests/unit/commands/contacts.test.ts
@@ -27,6 +27,11 @@ void mock.module("ora", () => ({
 const logServiceErrorCalls: unknown[] = [];
 void mock.module("../../../src/utils/command-error-handler.ts", () => ({
   logServiceError: (err: unknown) => { logServiceErrorCalls.push(err); },
+  handleServiceError: (err: unknown): never => {
+    logServiceErrorCalls.push(err);
+    process.exit(1);
+    return undefined as never;
+  },
 }));
 
 import { handleContactsCommand } from "../../../src/commands/contacts.ts";

--- a/tests/unit/commands/drive.test.ts
+++ b/tests/unit/commands/drive.test.ts
@@ -24,6 +24,11 @@ void mock.module("ora", () => ({
 const logServiceErrorCalls: unknown[] = [];
 void mock.module("../../../src/utils/command-error-handler.ts", () => ({
   logServiceError: (err: unknown) => { logServiceErrorCalls.push(err); },
+  handleServiceError: (err: unknown): never => {
+    logServiceErrorCalls.push(err);
+    process.exit(1);
+    return undefined as never;
+  },
 }));
 
 import { handleDriveCommand } from "../../../src/commands/drive.ts";

--- a/tests/unit/commands/mail.test.ts
+++ b/tests/unit/commands/mail.test.ts
@@ -23,6 +23,11 @@ void mock.module("ora", () => ({
 const logServiceErrorCalls: unknown[] = [];
 void mock.module("../../../src/utils/command-error-handler.ts", () => ({
   logServiceError: (err: unknown) => { logServiceErrorCalls.push(err); },
+  handleServiceError: (err: unknown): never => {
+    logServiceErrorCalls.push(err);
+    process.exit(1);
+    return undefined as never;
+  },
 }));
 
 import { handleMailCommand } from "../../../src/commands/mail.ts";


### PR DESCRIPTION
## What changed
- Removed the local `fatalExit` function from `cal.ts`, `contacts.ts`, `drive.ts`, and `mail.ts`
- Each file now imports and calls `handleServiceError` from `utils/command-error-handler.ts` directly
- Updated the `command-error-handler.ts` module mock in all 4 command test files to expose `handleServiceError` alongside `logServiceError`

## Why
`fatalExit` was a 4-line exact duplicate of `handleServiceError` that already existed (and was already exported) from `command-error-handler.ts`. All 4 command files imported `logServiceError` solely to implement their own copy of this function. The `resect similar` scan flagged this as Group 1 (exact duplicate after normalization).

## Testing
- `bun test --concurrent` — 252 pass, 3 pre-existing failures in `db-retry` and `auth-manager` (unrelated, confirmed pre-existing)
- `bun run lint` — clean

## Risk / Rollout
- Low risk: pure refactor, no behaviour change. `handleServiceError` does exactly what `fatalExit` did: call `logServiceError` then `process.exit(1)`.