### PR TITLE
fix(drive): detect insufficientPermissions as scope error

### DIFF
--- a/src/services/error-handler.ts
+++ b/src/services/error-handler.ts
@@ -84,7 +84,7 @@ const HTTP_ERROR_MAP: Record<number, ErrorFactory> = {
     new AuthenticationRequiredError(ctx),
   403: (ctx, _code, originalError) => {
     const reason = get403Reason(originalError);
-    if (reason === "ACCESS_TOKEN_SCOPE_INSUFFICIENT") {
+    if (reason === "ACCESS_TOKEN_SCOPE_INSUFFICIENT" || reason === "insufficientPermissions") {
       return new ScopeInsufficientError(ctx);
     }
     if (reason && API_NOT_ENABLED_REASONS.has(reason)) {

--- a/tests/unit/services/error-handler.test.ts
+++ b/tests/unit/services/error-handler.test.ts
@@ -209,6 +209,12 @@ describe("handleGoogleApiError", () => {
       ).toThrow(ScopeInsufficientError);
     });
 
+    it("throws ScopeInsufficientError for insufficientPermissions in errors[0].reason", () => {
+      expect(() =>
+        handleGoogleApiError(gaxiosError403("insufficientPermissions"), "list files")
+      ).toThrow(ScopeInsufficientError);
+    });
+
     it("ScopeInsufficientError carries the operation context in its message", () => {
       let thrown: unknown;
       try {


### PR DESCRIPTION
## Summary

- Map Google Drive API's `insufficientPermissions` 403 reason to `ScopeInsufficientError` so that `handleDriveCommand` triggers re-authorization instead of a fatal exit
- Add test case for the new reason detection

## Context

When running `gwork drive list` or `gwork drive get` for the first time, the stored token may lack Drive scopes. Google returns 403 with reason `insufficientPermissions`, but this was falling through to a generic `PermissionDeniedError` — which doesn't trigger re-auth. Now it correctly prompts the user to authorize Drive access.

## Test plan

- [x] `bun test --concurrent tests/unit/services/error-handler.test.ts` — 39 pass, 0 fail
- [x] `bun test --concurrent tests/unit/commands/drive.test.ts` — 7 pass, 0 fail
- [x] `bun run lint` — clean