### PR TITLE
fix(drive): actionable 404 errors; document version floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ The codebase is built with TypeScript using Bun as the primary runtime, with add
 ## Development Commands
 
 ```bash
-# Install dependencies
+# Install dependencies (required before build — bun run build fails on missing modules)
 bun install
 
 # Run CLI in development mode (direct execution)
@@ -273,6 +273,7 @@ const stream = info.message as NodeJS.ReadableStream; // Buffer | Readable — c
 ## Task Hygiene
 
 - **DO** call `TaskCreate` then `TaskUpdate` (status: `in_progress`) as the very first actions in every session, even for trivial single-command tasks like `pnpm link --global`. The `pretooluse-require-tasks` hook blocks Bash/Edit immediately if no `in_progress` task exists — there is no grace period.
+- **DO** always create at least one pending task alongside each in_progress task. CHECK 4 in `pretooluse-require-tasks` blocks Edit/Write/Bash when all incomplete tasks are in_progress and none are pending. Before the first Edit/Bash call, create both the in_progress work task and a pending "Verify changes" or similar next-step task.
 - **DON'T** assume that short tasks are exempt. The hook fires regardless of task complexity.
 
 ## Git & Contribution

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ gwork contacts detect-marketing --delete --confirm  # Remove marketing contacts
 
 ### Drive (Google Drive) - 10 Commands
 
+> **Note:** Drive support was added in gwork **v0.3.0**. If `gwork drive` is not available, upgrade with `npm i -g gwork@latest`.
+
 **List & Search:**
 ```bash
 gwork drive list                             # List recent files

--- a/src/services/error-handler.ts
+++ b/src/services/error-handler.ts
@@ -106,7 +106,15 @@ const HTTP_ERROR_MAP: Record<number, ErrorFactory> = {
     //   "get file" -> "File", "download file" -> "File", "get event" -> "Event"
     const lastWord = ctx.split(" ").pop() ?? ctx;
     const resourceType = lastWord.charAt(0).toUpperCase() + lastWord.slice(1);
-    return new NotFoundError(resourceType);
+    // For Drive file/folder operations, a 404 may mean a bad ID *or* no access —
+    // the Drive API returns 404 for both cases.  Give actionable guidance.
+    const isDriveFileOp = /\b(file|folder|download|upload)\b/i.test(ctx);
+    const hint = isDriveFileOp
+      ? "This can mean the ID is wrong or the signed-in account lacks access.\n"
+        + "  • Verify the file/folder ID from the sharing URL.\n"
+        + "  • Confirm the account has at least Viewer access (gwork accounts, --account <email>)."
+      : undefined;
+    return new NotFoundError(resourceType, undefined, hint);
   },
   429: () => new RateLimitError(),
   500: (ctx, code) => new ServiceUnavailableError(`Google ${ctx} service temporarily unavailable (HTTP ${code})`),

--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -26,9 +26,9 @@ export class ServiceError extends Error {
 }
 
 export class NotFoundError extends ServiceError {
-  constructor(resource: string, identifier?: string) {
+  constructor(resource: string, identifier?: string, hint?: string) {
     const msg = identifier ? `${resource} not found: ${identifier}` : `${resource} not found`;
-    super(msg, "NOT_FOUND", 404, false);
+    super(msg, "NOT_FOUND", 404, false, hint);
     Object.setPrototypeOf(this, NotFoundError.prototype);
   }
 }


### PR DESCRIPTION
## Summary

- Add Drive-specific hint to 404 handler distinguishing bad file ID from missing account access
- Add `hint` parameter to `NotFoundError` for contextual guidance
- Document Drive minimum version (v0.3.0) in README

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean  
- [x] `bun test --concurrent` — 256/256 pass

Fixes #108