### PR TITLE
chore: add *.docx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ credentials.json
 *.db
 *.db-shm
 *.db-wal
+
+# Downloaded documents
+*.docx


### PR DESCRIPTION
## Summary
- Add `*.docx` to `.gitignore` to exclude downloaded Google Drive documents from version control.