### PR TITLE
feat(sheets): add Google Sheets command group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**gwork** is a comprehensive CLI tool for Google Workspace (Calendar + Gmail). It provides 54 fully implemented commands (24 calendar + 30 Gmail) that expose the Google APIs through a developer-friendly command-line interface.
+**gwork** is a comprehensive CLI tool for Google Workspace (Calendar, Gmail, Drive, Contacts). It exposes the Google APIs through a developer-friendly command-line interface.
 
 The codebase is built with TypeScript using Bun as the primary runtime, with additional Node.js compatibility for CLI distribution via npm.
 
@@ -34,7 +34,20 @@ bun run build
 gwork --help
 gwork cal list
 gwork mail messages -n 5
+
+# Drive operations
+gwork drive list
+gwork drive download <fileId>                   # Downloads file; exports Google Docs as .docx
+gwork drive download <fileId> --output ./out.pdf
+gwork drive upload ./file.pdf --name "Report"
 ```
+
+### Extracting File IDs from Google URLs
+
+The `drive download` command takes a file ID, not a URL. Extract the ID from Google Workspace URLs:
+- `docs.google.com/document/d/<fileId>/edit` → use `<fileId>`
+- `docs.google.com/spreadsheets/d/<fileId>/edit` → use `<fileId>`
+- `drive.google.com/file/d/<fileId>/view` → use `<fileId>`
 
 ## Architecture
 
@@ -45,10 +58,18 @@ src/
 ├── cli.ts                      # Entry point; routes commands to handlers
 ├── commands/
 │   ├── accounts.ts             # Accounts command handler
-│   ├── cal.ts                  # Calendar command dispatcher (24 commands)
-│   └── mail.ts                 # Gmail command dispatcher (30 commands)
+│   ├── cal.ts                  # Calendar command dispatcher
+│   ├── contacts.ts             # Contacts command dispatcher
+│   ├── drive.ts                # Drive command dispatcher (list, get, search, download, upload, delete, mkdir, move, share, stats)
+│   ├── mail.ts                 # Gmail command dispatcher
+│   └── registry.ts             # Command registry
 ├── services/
+│   ├── auth-manager.ts         # OAuth2 authentication manager
+│   ├── base-service.ts         # Base service class
 │   ├── calendar-service.ts     # Google Calendar API wrapper
+│   ├── contacts-service.ts     # Google Contacts API wrapper
+│   ├── drive-service.ts        # Google Drive API wrapper
+│   ├── error-handler.ts        # Centralized error handling
 │   ├── mail-service.ts         # Gmail API wrapper
 │   └── token-store.ts          # Multi-account token persistence (SQLite)
 ├── utils/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { handleCalCommand } from "./commands/cal.ts";
 import { handleContactsCommand } from "./commands/contacts.ts";
 import { handleAccountsCommand } from "./commands/accounts.ts";
 import { handleDriveCommand } from "./commands/drive.ts";
+import { handleSheetsCommand } from "./commands/sheets.ts";
 import { CommandRegistry } from "./commands/registry.ts";
 import { parseAccount } from "./utils/args.ts";
 import { logServiceError } from "./utils/command-error-handler.ts";
@@ -23,6 +24,7 @@ Commands:
   cal            Google Calendar operations
   contacts       Google Contacts operations
   drive          Google Drive operations
+  sheets         Google Sheets operations
   accounts       List configured Google accounts
 
 Options:
@@ -210,7 +212,7 @@ Commands:
   list [options]                  List files and folders
   get <fileId>                    Get metadata for a specific file
   search <query>                  Search files using Drive query syntax
-  download <fileId>               Download a file to local disk
+  download <fileId>               Download a file (Sheets: --format csv|tsv|xlsx|pdf)
   upload <path>                   Upload a local file to Drive
   delete <fileId> --confirm       Delete a file
   mkdir <name>                    Create a new folder
@@ -223,6 +225,7 @@ Options:
   --max-results <number>          Maximum number of results to return (default: 10)
   --folder <folderId>             Filter by folder / set parent folder
   --output <path>                 Destination path for download
+  --format <csv|tsv|xlsx|pdf>     Export format for Google Sheets (default: xlsx)
   --name <name>                   Override file name for upload
 
 Examples:
@@ -232,11 +235,49 @@ Examples:
   gwork drive get <fileId>
   gwork drive download <fileId>
   gwork drive download <fileId> --output ./report.pdf
+  gwork drive download <fileId> --format csv
   gwork drive upload ./report.pdf --name "Q4 Report"
   gwork drive mkdir "Projects"
   gwork drive move <fileId> <folderId>
   gwork drive share <fileId>
   gwork drive stats
+`);
+}
+
+function printSheetsHelp() {
+  console.log(`
+gwork sheets - Google Sheets operations
+
+Usage:
+  gwork sheets <command> [options]
+
+Commands:
+  list <fileId>                     List sheets/tabs in a spreadsheet
+  get <fileId>                      Get spreadsheet metadata
+  read <fileId> [range]             Read and display cell data
+  export <fileId>                   Export sheet data as CSV
+  append <fileId> <range> <values>  Append rows to a sheet
+
+Options:
+  -h, --help                        Show this help message
+
+Read options:
+  --format <table|csv|json>         Output format (default: table)
+  --no-header                       Don't treat first row as header
+
+Export options:
+  --sheet <name>                    Sheet/tab name to export (default: first sheet)
+  --output <path>                   Write to file instead of stdout
+
+Examples:
+  gwork sheets list <fileId>
+  gwork sheets read <fileId>
+  gwork sheets read <fileId> "Sheet1!A1:D10"
+  gwork sheets read <fileId> --format csv
+  gwork sheets read <fileId> --format json
+  gwork sheets export <fileId> --output data.csv
+  gwork sheets export <fileId> --sheet "Sheet2" --output sheet2.csv
+  gwork sheets append <fileId> "Sheet1!A:D" "Alice,30,NYC" "Bob,25,LA"
 `);
 }
 
@@ -323,6 +364,32 @@ async function handleDrive(args: string[]) {
   await handleDriveCommand(subcommand, filteredArgs, account);
 }
 
+async function handleSheets(args: string[]) {
+  // Check for help flag or no subcommand
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printSheetsHelp();
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  if (!subcommand) {
+    printSheetsHelp();
+    process.exit(0);
+  }
+  const subcommandArgs = args.slice(1);
+
+  // Extract account from subcommand args
+  const { account, args: filteredArgs } = parseAccount(subcommandArgs);
+
+  // If --help/-h appears in subcommand args, show parent help
+  if (filteredArgs.includes("--help") || filteredArgs.includes("-h")) {
+    printSheetsHelp();
+    process.exit(0);
+  }
+
+  await handleSheetsCommand(subcommand, filteredArgs, account);
+}
+
 async function handleContacts(args: string[]) {
   // Check for help flag or no subcommand
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
@@ -386,6 +453,7 @@ const topLevelRegistry = new CommandRegistry<null>()
   .register("cal", (_svc, args) => handleCal(args))
   .register("contacts", (_svc, args) => handleContacts(args))
   .register("drive", (_svc, args) => handleDrive(args))
+  .register("sheets", (_svc, args) => handleSheets(args))
   .register("accounts", (_svc, args) => handleAccountsCommand(args));
 
 main().catch((error) => {

--- a/src/commands/drive.ts
+++ b/src/commands/drive.ts
@@ -112,9 +112,31 @@ async function downloadFile(svc: DriveService, fileId: string, args: string[]): 
   const positionalDest = args[0] && !args[0].startsWith("--") ? args[0] : undefined;
   let destPath: string | undefined = outputFlag !== -1 ? args[outputFlag + 1] : positionalDest;
 
+  // Check for --format flag (for Google Sheets export as csv/tsv/pdf)
+  const formatIdx = args.indexOf("--format");
+  const format = formatIdx !== -1 ? args[formatIdx + 1] : undefined;
+
+  // Map format to extension for auto-naming
+  const formatExtMap: Record<string, string> = {
+    csv: ".csv",
+    tsv: ".tsv",
+    pdf: ".pdf",
+    xlsx: ".xlsx",
+  };
+
   // Always fetch metadata — needed for filename when dest is a directory or omitted
   const file = await svc.getFile(fileId);
-  const safeName = file.name.replace(/[/\\?%*:|"<>]/g, "_");
+  let safeName = file.name.replace(/[/\\?%*:|"<>]/g, "_");
+
+  // Override extension when --format is used on a Google Sheet
+  if (format && file.mimeType === "application/vnd.google-apps.spreadsheet") {
+    const ext = formatExtMap[format.toLowerCase()];
+    if (ext) {
+      // Replace existing extension or append
+      const base = safeName.replace(/\.[^.]+$/, "");
+      safeName = base + ext;
+    }
+  }
 
   if (destPath) {
     const resolved = path.resolve(destPath);
@@ -129,7 +151,7 @@ async function downloadFile(svc: DriveService, fileId: string, args: string[]): 
   }
 
   const spinner = ora(`Downloading "${file.name}"…`).start();
-  await svc.downloadFile(fileId, destPath);
+  await svc.downloadFile(fileId, destPath, format);
   spinner.stop();
   console.log(`Downloaded: ${chalk.bold(destPath)}`);
 }

--- a/src/commands/sheets.ts
+++ b/src/commands/sheets.ts
@@ -1,0 +1,261 @@
+import chalk from "chalk";
+import ora from "ora";
+import { SheetsService } from "../services/sheets-service.ts";
+import { ArgumentError } from "../services/errors.ts";
+import { handleCommandWithRetry } from "../utils/command-handler.ts";
+import { CommandRegistry } from "./registry.ts";
+
+/**
+ * Render a 2D array as a formatted table with column alignment.
+ */
+function renderTable(values: string[][], hasHeader: boolean): void {
+  if (values.length === 0) {
+    console.log(chalk.gray("(empty)"));
+    return;
+  }
+
+  // Calculate column widths
+  const colCount = Math.max(...values.map((r) => r.length));
+  const widths: number[] = Array.from({ length: colCount }, () => 0);
+
+  for (const row of values) {
+    for (let i = 0; i < colCount; i++) {
+      const cell = row[i] ?? "";
+      widths[i] = Math.max(widths[i]!, cell.length);
+    }
+  }
+
+  // Cap column widths to keep output manageable
+  const maxColWidth = 40;
+  for (let i = 0; i < widths.length; i++) {
+    widths[i] = Math.min(widths[i]!, maxColWidth);
+  }
+
+  const formatRow = (row: string[]): string => {
+    return row
+      .map((cell, i) => {
+        const w = widths[i] ?? 10;
+        const truncated = cell.length > w ? cell.slice(0, w - 1) + "…" : cell;
+        return truncated.padEnd(w);
+      })
+      .join("  ");
+  };
+
+  const separator = widths.map((w) => "─".repeat(w)).join("──");
+
+  if (hasHeader && values.length > 0) {
+    console.log(chalk.bold(formatRow(values[0]!)));
+    console.log(chalk.gray(separator));
+    for (const row of values.slice(1)) {
+      console.log(formatRow(row));
+    }
+  } else {
+    for (const row of values) {
+      console.log(formatRow(row));
+    }
+  }
+}
+
+/**
+ * Convert a 2D array to CSV format.
+ */
+function toCsv(values: string[][]): string {
+  return values
+    .map((row) =>
+      row
+        .map((cell) => {
+          // Quote cells that contain commas, quotes, or newlines
+          if (cell.includes(",") || cell.includes('"') || cell.includes("\n")) {
+            return `"${cell.replace(/"/g, '""')}"`;
+          }
+          return cell;
+        })
+        .join(",")
+    )
+    .join("\n");
+}
+
+async function listSheets(svc: SheetsService, spreadsheetId: string): Promise<void> {
+  const spinner = ora("Fetching spreadsheet info…").start();
+  const meta = await svc.getSpreadsheet(spreadsheetId);
+  spinner.stop();
+
+  console.log(`${chalk.bold(meta.title)}`);
+  console.log(`${chalk.gray(meta.url)}\n`);
+
+  for (const sheet of meta.sheets) {
+    const hidden = sheet.hidden ? chalk.red(" (hidden)") : "";
+    const dims = chalk.gray(`${sheet.rowCount}×${sheet.columnCount}`);
+    console.log(`  ${chalk.cyan(sheet.title)} ${dims}${hidden}`);
+  }
+  console.log(chalk.gray(`\n${meta.sheets.length} sheet(s)`));
+}
+
+async function getSpreadsheet(svc: SheetsService, spreadsheetId: string): Promise<void> {
+  const spinner = ora("Fetching spreadsheet metadata…").start();
+  const meta = await svc.getSpreadsheet(spreadsheetId);
+  spinner.stop();
+
+  console.log(`Title:    ${chalk.bold(meta.title)}`);
+  console.log(`ID:       ${meta.spreadsheetId}`);
+  console.log(`Locale:   ${meta.locale}`);
+  console.log(`Timezone: ${meta.timeZone}`);
+  console.log(`Sheets:   ${meta.sheets.length}`);
+  console.log(`Link:     ${meta.url}`);
+
+  if (meta.sheets.length > 0) {
+    console.log(`\n${chalk.bold("Sheets:")}`);
+    for (const sheet of meta.sheets) {
+      const hidden = sheet.hidden ? chalk.red(" (hidden)") : "";
+      console.log(`  ${sheet.index + 1}. ${chalk.cyan(sheet.title)} — ${sheet.rowCount}×${sheet.columnCount}${hidden}`);
+    }
+  }
+}
+
+async function readSheet(svc: SheetsService, spreadsheetId: string, args: string[]): Promise<void> {
+  // Range is the first non-flag argument
+  const range = args[0] && !args[0].startsWith("--") ? args[0] : undefined;
+  const noHeader = args.includes("--no-header");
+  const format = extractFlag(args, "--format") || "table";
+
+  const spinner = ora("Reading sheet data…").start();
+  const data = await svc.readRange(spreadsheetId, range);
+  spinner.stop();
+
+  console.log(chalk.gray(`Range: ${data.range}  (${data.values.length} rows)\n`));
+
+  if (data.values.length === 0) {
+    console.log(chalk.gray("No data found."));
+    return;
+  }
+
+  if (format === "csv") {
+    console.log(toCsv(data.values));
+  } else if (format === "json") {
+    if (data.values.length > 1 && !noHeader) {
+      const headers = data.values[0]!;
+      const rows = data.values.slice(1).map((row) => {
+        const obj: Record<string, string> = {};
+        for (let i = 0; i < headers.length; i++) {
+          obj[headers[i]!] = row[i] ?? "";
+        }
+        return obj;
+      });
+      console.log(JSON.stringify(rows, null, 2));
+    } else {
+      console.log(JSON.stringify(data.values, null, 2));
+    }
+  } else {
+    renderTable(data.values, !noHeader);
+  }
+}
+
+async function exportSheet(svc: SheetsService, spreadsheetId: string, args: string[]): Promise<void> {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
+  const sheetName = extractFlag(args, "--sheet");
+  const outputPath = extractFlag(args, "--output");
+
+  const range = sheetName || undefined;
+
+  const spinner = ora("Exporting sheet data…").start();
+  const data = await svc.readRange(spreadsheetId, range);
+  spinner.stop();
+
+  const csv = toCsv(data.values);
+
+  if (outputPath) {
+    const resolved = path.resolve(outputPath);
+    fs.writeFileSync(resolved, csv, "utf-8");
+    console.log(`Exported ${data.values.length} rows to ${chalk.bold(resolved)}`);
+  } else {
+    console.log(csv);
+  }
+}
+
+async function appendRows(svc: SheetsService, spreadsheetId: string, args: string[]): Promise<void> {
+  if (args.length < 2) {
+    throw new ArgumentError(
+      "Error: range and values are required",
+      'gwork sheets append <fileId> <range> <value1,value2,...> [<value3,value4,...>]'
+    );
+  }
+
+  const range = args[0]!;
+  // Each remaining arg is a comma-separated row
+  const values = args.slice(1).map((row) => row.split(","));
+
+  const spinner = ora("Appending rows…").start();
+  const result = await svc.appendRows(spreadsheetId, range, values);
+  spinner.stop();
+
+  console.log(`Appended ${chalk.bold(String(result.updatedRows))} row(s) to ${chalk.cyan(result.updatedRange)}`);
+}
+
+/**
+ * Extract a flag value from args (e.g., --format csv → "csv").
+ */
+function extractFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+function buildSheetsRegistry(): CommandRegistry<SheetsService> {
+  return new CommandRegistry<SheetsService>()
+    .register("list", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError("Error: spreadsheet ID is required", "gwork sheets list <fileId>");
+      }
+      return listSheets(svc, args[0]!);
+    })
+    .register("get", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError("Error: spreadsheet ID is required", "gwork sheets get <fileId>");
+      }
+      return getSpreadsheet(svc, args[0]!);
+    })
+    .register("read", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError(
+          "Error: spreadsheet ID is required",
+          "gwork sheets read <fileId> [range] [--format table|csv|json] [--no-header]"
+        );
+      }
+      return readSheet(svc, args[0]!, args.slice(1));
+    })
+    .register("export", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError(
+          "Error: spreadsheet ID is required",
+          "gwork sheets export <fileId> [--sheet <name>] [--output <path>]"
+        );
+      }
+      return exportSheet(svc, args[0]!, args.slice(1));
+    })
+    .register("append", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError(
+          "Error: spreadsheet ID is required",
+          'gwork sheets append <fileId> <range> <val1,val2,...>'
+        );
+      }
+      return appendRows(svc, args[0]!, args.slice(1));
+    });
+}
+
+export async function handleSheetsCommand(
+  subcommand: string,
+  args: string[],
+  account = "default",
+  serviceFactory: (account: string) => SheetsService = (acc) => new SheetsService(acc)
+) {
+  await handleCommandWithRetry({
+    tokenKey: "sheets",
+    serviceName: "Sheets",
+    account,
+    subcommand,
+    serviceFactory,
+    execute: (svc) => buildSheetsRegistry().execute(subcommand, svc, args),
+  });
+}

--- a/src/services/drive-service.ts
+++ b/src/services/drive-service.ts
@@ -126,7 +126,7 @@ export class DriveService extends BaseService {
     }
   }
 
-  async downloadFile(fileId: string, destPath: string): Promise<void> {
+  async downloadFile(fileId: string, destPath: string, format?: string): Promise<void> {
     await this.initialize();
     this.ensureInitialized();
 
@@ -150,10 +150,26 @@ export class DriveService extends BaseService {
         "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
       };
 
+      // Format-specific overrides for Google Sheets
+      const sheetExportFormats: Record<string, { mime: string; ext: string }> = {
+        csv: { mime: "text/csv", ext: ".csv" },
+        tsv: { mime: "text/tab-separated-values", ext: ".tsv" },
+        xlsx: { mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ext: ".xlsx" },
+        pdf: { mime: "application/pdf", ext: ".pdf" },
+      };
+
       const resolvedDest = path.resolve(destPath);
       const dest = fs.createWriteStream(resolvedDest);
 
-      const exportMime = exportMimeMap[mimeType];
+      // Allow format override for Sheets (e.g., --format csv)
+      let exportMime = exportMimeMap[mimeType];
+      if (format && mimeType === "application/vnd.google-apps.spreadsheet") {
+        const formatOverride = sheetExportFormats[format.toLowerCase()];
+        if (formatOverride) {
+          exportMime = formatOverride.mime;
+        }
+      }
+
       if (exportMime) {
         const response = await this.drive!.files.export(
           { fileId, mimeType: exportMime },

--- a/src/services/sheets-service.ts
+++ b/src/services/sheets-service.ts
@@ -1,0 +1,185 @@
+/**
+ * Google Sheets service wrapper for Google Sheets API v4.
+ * Provides methods for reading spreadsheet data, listing sheets,
+ * and appending rows.
+ */
+
+import { google } from "googleapis";
+import { BaseService } from "./base-service.ts";
+import { handleGoogleApiError } from "./error-handler.ts";
+import type { sheets_v4 } from "googleapis";
+
+export interface SheetInfo {
+  sheetId: number;
+  title: string;
+  index: number;
+  rowCount: number;
+  columnCount: number;
+  hidden: boolean;
+}
+
+export interface SpreadsheetMeta {
+  spreadsheetId: string;
+  title: string;
+  locale: string;
+  timeZone: string;
+  sheets: SheetInfo[];
+  url: string;
+}
+
+export interface SheetData {
+  range: string;
+  values: string[][];
+}
+
+export class SheetsService extends BaseService {
+  private sheets: sheets_v4.Sheets | null = null;
+
+  constructor(account = "default") {
+    super(
+      "Sheets",
+      [
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+        "https://www.googleapis.com/auth/spreadsheets",
+      ],
+      account
+    );
+  }
+
+  override async initialize(): Promise<void> {
+    await super.initialize();
+    this.ensureInitialized();
+    this.sheets = google.sheets({ version: "v4", auth: this.getAuth() });
+  }
+
+  /**
+   * Get spreadsheet metadata including all sheet/tab names.
+   */
+  async getSpreadsheet(spreadsheetId: string): Promise<SpreadsheetMeta> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.sheets!.spreadsheets.get({
+        spreadsheetId,
+        fields: "spreadsheetId,properties(title,locale,timeZone),spreadsheetUrl,sheets(properties(sheetId,title,index,gridProperties(rowCount,columnCount),hidden))",
+      });
+
+      const props = result.data.properties || {};
+      const sheetsData = result.data.sheets || [];
+
+      return {
+        spreadsheetId: result.data.spreadsheetId || spreadsheetId,
+        title: props.title || "",
+        locale: props.locale || "",
+        timeZone: props.timeZone || "",
+        url: result.data.spreadsheetUrl || "",
+        sheets: sheetsData.map((s) => {
+          const sp = s.properties || {};
+          const gp = sp.gridProperties || {};
+          return {
+            sheetId: sp.sheetId || 0,
+            title: sp.title || "",
+            index: sp.index || 0,
+            rowCount: gp.rowCount || 0,
+            columnCount: gp.columnCount || 0,
+            hidden: sp.hidden || false,
+          };
+        }),
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "get spreadsheet");
+    }
+  }
+
+  /**
+   * Read cell values from a range (e.g. "Sheet1!A1:D10" or "A1:D10").
+   * If no range is given, reads the first sheet entirely.
+   */
+  async readRange(spreadsheetId: string, range?: string): Promise<SheetData> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    // If no range specified, read the first sheet
+    const effectiveRange = range || (await this.getFirstSheetName(spreadsheetId));
+
+    try {
+      const result = await this.sheets!.spreadsheets.values.get({
+        spreadsheetId,
+        range: effectiveRange,
+        valueRenderOption: "FORMATTED_VALUE",
+        dateTimeRenderOption: "FORMATTED_STRING",
+      });
+
+      return {
+        range: result.data.range || effectiveRange,
+        values: (result.data.values || []) as string[][],
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "read range");
+    }
+  }
+
+  /**
+   * Read multiple ranges in a single API call.
+   */
+  async readRanges(spreadsheetId: string, ranges: string[]): Promise<SheetData[]> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.sheets!.spreadsheets.values.batchGet({
+        spreadsheetId,
+        ranges,
+        valueRenderOption: "FORMATTED_VALUE",
+        dateTimeRenderOption: "FORMATTED_STRING",
+      });
+
+      return (result.data.valueRanges || []).map((vr) => ({
+        range: vr.range || "",
+        values: (vr.values || []) as string[][],
+      }));
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "read ranges");
+    }
+  }
+
+  /**
+   * Append rows to a sheet range.
+   */
+  async appendRows(
+    spreadsheetId: string,
+    range: string,
+    values: string[][]
+  ): Promise<{ updatedRange: string; updatedRows: number }> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.sheets!.spreadsheets.values.append({
+        spreadsheetId,
+        range,
+        valueInputOption: "USER_ENTERED",
+        insertDataOption: "INSERT_ROWS",
+        requestBody: { values },
+      });
+
+      const updates = result.data.updates || {};
+      return {
+        updatedRange: updates.updatedRange || range,
+        updatedRows: updates.updatedRows || values.length,
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "append rows");
+    }
+  }
+
+  /**
+   * Get the name of the first (visible) sheet in the spreadsheet.
+   */
+  private async getFirstSheetName(spreadsheetId: string): Promise<string> {
+    const meta = await this.getSpreadsheet(spreadsheetId);
+    const firstVisible = meta.sheets.find((s) => !s.hidden);
+    return firstVisible?.title || meta.sheets[0]?.title || "Sheet1";
+  }
+}


### PR DESCRIPTION
## Summary
- New `gwork sheets` command group with 5 subcommands: `list`, `get`, `read`, `export`, `append`
- `read` outputs as formatted table, CSV, or JSON with `--format` flag
- `export` writes sheet data as CSV to stdout or file with `--sheet` and `--output` options
- `append` adds rows to a sheet range
- New `--format` flag on `drive download` for exporting Google Sheets as csv/tsv/xlsx/pdf
- Updated CLAUDE.md architecture to include Drive, Contacts, and Sheets

## Test plan
- [x] All 256 existing tests pass
- [x] ESLint clean
- [x] TypeScript type check clean
- [x] `gwork sheets --help` displays correctly
- [ ] Manual: `gwork sheets list <sheetId>` lists tabs
- [ ] Manual: `gwork sheets read <sheetId>` displays data as table
- [ ] Manual: `gwork drive download <sheetId> --format csv` exports as CSV