### PR TITLE
feat(docs,slides): add Docs and Slides command groups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import { handleContactsCommand } from "./commands/contacts.ts";
 import { handleAccountsCommand } from "./commands/accounts.ts";
 import { handleDriveCommand } from "./commands/drive.ts";
 import { handleSheetsCommand } from "./commands/sheets.ts";
+import { handleDocsCommand } from "./commands/docs.ts";
+import { handleSlidesCommand } from "./commands/slides.ts";
 import { CommandRegistry } from "./commands/registry.ts";
 import { parseAccount } from "./utils/args.ts";
 import { logServiceError } from "./utils/command-error-handler.ts";
@@ -25,6 +27,8 @@ Commands:
   contacts       Google Contacts operations
   drive          Google Drive operations
   sheets         Google Sheets operations
+  docs           Google Docs operations
+  slides         Google Slides operations
   accounts       List configured Google accounts
 
 Options:
@@ -281,6 +285,62 @@ Examples:
 `);
 }
 
+function printDocsHelp() {
+  console.log(`
+gwork docs - Google Docs operations
+
+Usage:
+  gwork docs <command> [options]
+
+Commands:
+  get <fileId>                      Get document metadata
+  read <fileId>                     Read and display document content as text
+
+Options:
+  -h, --help                        Show this help message
+
+Read options:
+  --headers                         Show only headings (table of contents)
+  --format <text|json>              Output format (default: text)
+
+Examples:
+  gwork docs get <fileId>
+  gwork docs read <fileId>
+  gwork docs read <fileId> --headers
+  gwork docs read <fileId> --format json
+`);
+}
+
+function printSlidesHelp() {
+  console.log(`
+gwork slides - Google Slides operations
+
+Usage:
+  gwork slides <command> [options]
+
+Commands:
+  get <fileId>                      Get presentation metadata
+  list <fileId>                     List all slides with titles
+  read <fileId>                     Read slide content and speaker notes
+  thumbnail <fileId> <slideNum>     Get thumbnail URL for a slide
+
+Options:
+  -h, --help                        Show this help message
+
+Read options:
+  --notes                           Show only slides with speaker notes
+  --format <text|json>              Output format (default: text)
+
+Examples:
+  gwork slides get <fileId>
+  gwork slides list <fileId>
+  gwork slides read <fileId>
+  gwork slides read <fileId> --notes
+  gwork slides read <fileId> --format json
+  gwork slides thumbnail <fileId> 3
+`);
+}
+
 function printVersion() {
   const buildTime = typeof __BUILD_TIME__ !== "undefined" ? ` (built ${__BUILD_TIME__})` : "";
   console.log(`gwork version 0.3.2${buildTime}`);
@@ -390,6 +450,50 @@ async function handleSheets(args: string[]) {
   await handleSheetsCommand(subcommand, filteredArgs, account);
 }
 
+async function handleDocs(args: string[]) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printDocsHelp();
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  if (!subcommand) {
+    printDocsHelp();
+    process.exit(0);
+  }
+  const subcommandArgs = args.slice(1);
+  const { account, args: filteredArgs } = parseAccount(subcommandArgs);
+
+  if (filteredArgs.includes("--help") || filteredArgs.includes("-h")) {
+    printDocsHelp();
+    process.exit(0);
+  }
+
+  await handleDocsCommand(subcommand, filteredArgs, account);
+}
+
+async function handleSlides(args: string[]) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printSlidesHelp();
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  if (!subcommand) {
+    printSlidesHelp();
+    process.exit(0);
+  }
+  const subcommandArgs = args.slice(1);
+  const { account, args: filteredArgs } = parseAccount(subcommandArgs);
+
+  if (filteredArgs.includes("--help") || filteredArgs.includes("-h")) {
+    printSlidesHelp();
+    process.exit(0);
+  }
+
+  await handleSlidesCommand(subcommand, filteredArgs, account);
+}
+
 async function handleContacts(args: string[]) {
   // Check for help flag or no subcommand
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
@@ -454,6 +558,8 @@ const topLevelRegistry = new CommandRegistry<null>()
   .register("contacts", (_svc, args) => handleContacts(args))
   .register("drive", (_svc, args) => handleDrive(args))
   .register("sheets", (_svc, args) => handleSheets(args))
+  .register("docs", (_svc, args) => handleDocs(args))
+  .register("slides", (_svc, args) => handleSlides(args))
   .register("accounts", (_svc, args) => handleAccountsCommand(args));
 
 main().catch((error) => {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,0 +1,93 @@
+import chalk from "chalk";
+import ora from "ora";
+import { DocsService } from "../services/docs-service.ts";
+import { ArgumentError } from "../services/errors.ts";
+import { handleCommandWithRetry } from "../utils/command-handler.ts";
+import { CommandRegistry } from "./registry.ts";
+
+async function getDoc(svc: DocsService, documentId: string): Promise<void> {
+  const spinner = ora("Fetching document metadata…").start();
+  const meta = await svc.getDocument(documentId);
+  spinner.stop();
+
+  console.log(`Title:       ${chalk.bold(meta.title)}`);
+  console.log(`ID:          ${meta.documentId}`);
+  console.log(`Revision:    ${meta.revisionId}`);
+  console.log(`Link:        https://docs.google.com/document/d/${meta.documentId}/edit`);
+}
+
+async function readDoc(svc: DocsService, documentId: string, args: string[]): Promise<void> {
+  const headersOnly = args.includes("--headers");
+  const format = extractFlag(args, "--format") || "text";
+
+  const spinner = ora("Reading document…").start();
+  const content = await svc.readContent(documentId);
+  spinner.stop();
+
+  if (format === "json") {
+    const output = {
+      documentId: content.documentId,
+      title: content.title,
+      wordCount: content.wordCount,
+      headers: content.headers,
+      body: headersOnly ? undefined : content.bodyText,
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold(content.title));
+  console.log(chalk.gray(`${content.wordCount} words\n`));
+
+  if (headersOnly) {
+    if (content.headers.length === 0) {
+      console.log(chalk.gray("No headings found."));
+    } else {
+      for (const header of content.headers) {
+        console.log(`  ${chalk.cyan(header)}`);
+      }
+    }
+  } else {
+    console.log(content.bodyText);
+  }
+}
+
+function extractFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+function buildDocsRegistry(): CommandRegistry<DocsService> {
+  return new CommandRegistry<DocsService>()
+    .register("get", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError("Error: document ID is required", "gwork docs get <fileId>");
+      }
+      return getDoc(svc, args[0]!);
+    })
+    .register("read", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError(
+          "Error: document ID is required",
+          "gwork docs read <fileId> [--headers] [--format text|json]"
+        );
+      }
+      return readDoc(svc, args[0]!, args.slice(1));
+    });
+}
+
+export async function handleDocsCommand(
+  subcommand: string,
+  args: string[],
+  account = "default",
+  serviceFactory: (account: string) => DocsService = (acc) => new DocsService(acc)
+) {
+  await handleCommandWithRetry({
+    tokenKey: "docs",
+    serviceName: "Docs",
+    account,
+    subcommand,
+    serviceFactory,
+    execute: (svc) => buildDocsRegistry().execute(subcommand, svc, args),
+  });
+}

--- a/src/commands/drive.ts
+++ b/src/commands/drive.ts
@@ -112,7 +112,7 @@ async function downloadFile(svc: DriveService, fileId: string, args: string[]): 
   const positionalDest = args[0] && !args[0].startsWith("--") ? args[0] : undefined;
   let destPath: string | undefined = outputFlag !== -1 ? args[outputFlag + 1] : positionalDest;
 
-  // Check for --format flag (for Google Sheets export as csv/tsv/pdf)
+  // Check for --format flag (for Google Workspace file export)
   const formatIdx = args.indexOf("--format");
   const format = formatIdx !== -1 ? args[formatIdx + 1] : undefined;
 
@@ -122,17 +122,31 @@ async function downloadFile(svc: DriveService, fileId: string, args: string[]): 
     tsv: ".tsv",
     pdf: ".pdf",
     xlsx: ".xlsx",
+    txt: ".txt",
+    text: ".txt",
+    html: ".html",
+    rtf: ".rtf",
+    epub: ".epub",
+    docx: ".docx",
+    pptx: ".pptx",
+    md: ".md",
   };
+
+  // Google Workspace MIME types that support --format
+  const workspaceMimeTypes = [
+    "application/vnd.google-apps.spreadsheet",
+    "application/vnd.google-apps.document",
+    "application/vnd.google-apps.presentation",
+  ];
 
   // Always fetch metadata — needed for filename when dest is a directory or omitted
   const file = await svc.getFile(fileId);
   let safeName = file.name.replace(/[/\\?%*:|"<>]/g, "_");
 
-  // Override extension when --format is used on a Google Sheet
-  if (format && file.mimeType === "application/vnd.google-apps.spreadsheet") {
+  // Override extension when --format is used on a Google Workspace file
+  if (format && workspaceMimeTypes.includes(file.mimeType)) {
     const ext = formatExtMap[format.toLowerCase()];
     if (ext) {
-      // Replace existing extension or append
       const base = safeName.replace(/\.[^.]+$/, "");
       safeName = base + ext;
     }

--- a/src/commands/slides.ts
+++ b/src/commands/slides.ts
@@ -1,0 +1,157 @@
+import chalk from "chalk";
+import ora from "ora";
+import { SlidesService } from "../services/slides-service.ts";
+import { ArgumentError } from "../services/errors.ts";
+import { handleCommandWithRetry } from "../utils/command-handler.ts";
+import { CommandRegistry } from "./registry.ts";
+
+async function getPresentation(svc: SlidesService, presentationId: string): Promise<void> {
+  const spinner = ora("Fetching presentation metadata…").start();
+  const meta = await svc.getPresentation(presentationId);
+  spinner.stop();
+
+  console.log(`Title:    ${chalk.bold(meta.title)}`);
+  console.log(`ID:       ${meta.presentationId}`);
+  console.log(`Locale:   ${meta.locale}`);
+  console.log(`Slides:   ${meta.slideCount}`);
+  console.log(`Masters:  ${meta.masterCount}`);
+  console.log(`Layouts:  ${meta.layoutCount}`);
+  console.log(`Link:     https://docs.google.com/presentation/d/${meta.presentationId}/edit`);
+}
+
+async function listSlides(svc: SlidesService, presentationId: string): Promise<void> {
+  const spinner = ora("Fetching slides…").start();
+  const meta = await svc.getPresentation(presentationId);
+  spinner.stop();
+
+  console.log(`${chalk.bold(meta.title)}`);
+  console.log(chalk.gray(`https://docs.google.com/presentation/d/${meta.presentationId}/edit\n`));
+
+  for (let i = 0; i < meta.slides.length; i++) {
+    const slide = meta.slides[i]!;
+    const notes = slide.speakerNotes ? chalk.gray(` — ${truncate(slide.speakerNotes, 60)}`) : "";
+    console.log(`  ${chalk.cyan(`${i + 1}.`)} ${slide.title}${notes}`);
+  }
+
+  console.log(chalk.gray(`\n${meta.slideCount} slide(s)`));
+}
+
+async function readSlides(svc: SlidesService, presentationId: string, args: string[]): Promise<void> {
+  const format = extractFlag(args, "--format") || "text";
+  const notesOnly = args.includes("--notes");
+
+  const spinner = ora("Reading presentation…").start();
+  const content = await svc.readContent(presentationId);
+  spinner.stop();
+
+  if (format === "json") {
+    console.log(JSON.stringify(content, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold(content.title));
+  console.log(chalk.gray(`${content.slides.length} slides\n`));
+
+  for (let i = 0; i < content.slides.length; i++) {
+    const slide = content.slides[i]!;
+
+    if (notesOnly) {
+      if (slide.speakerNotes) {
+        console.log(`${chalk.cyan(`Slide ${i + 1}:`)} ${slide.title}`);
+        console.log(`  ${slide.speakerNotes}\n`);
+      }
+    } else {
+      console.log(chalk.cyan(`── Slide ${i + 1}: ${slide.title} ──`));
+      if (slide.speakerNotes) {
+        console.log(chalk.gray(`  Notes: ${slide.speakerNotes}`));
+      }
+      console.log();
+    }
+  }
+}
+
+async function thumbnailSlide(svc: SlidesService, presentationId: string, args: string[]): Promise<void> {
+  const slideIndex = parseInt(args[0] || "1", 10);
+  if (isNaN(slideIndex) || slideIndex < 1) {
+    throw new ArgumentError("Error: slide number must be a positive integer", "gwork slides thumbnail <fileId> <slideNumber>");
+  }
+
+  const spinner = ora("Fetching presentation…").start();
+  const meta = await svc.getPresentation(presentationId);
+
+  if (slideIndex > meta.slides.length) {
+    spinner.stop();
+    throw new ArgumentError(
+      `Error: slide ${slideIndex} does not exist (presentation has ${meta.slides.length} slides)`,
+      `gwork slides thumbnail <fileId> <1-${meta.slides.length}>`
+    );
+  }
+
+  const slide = meta.slides[slideIndex - 1]!;
+  spinner.text = `Fetching thumbnail for slide ${slideIndex}…`;
+  const url = await svc.getSlideThumbnail(presentationId, slide.objectId);
+  spinner.stop();
+
+  console.log(`Slide ${slideIndex}: ${chalk.bold(slide.title)}`);
+  console.log(`Thumbnail: ${chalk.underline(url)}`);
+}
+
+function extractFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+function truncate(text: string, max: number): string {
+  const oneLine = text.replace(/\n/g, " ");
+  return oneLine.length > max ? oneLine.slice(0, max - 1) + "…" : oneLine;
+}
+
+function buildSlidesRegistry(): CommandRegistry<SlidesService> {
+  return new CommandRegistry<SlidesService>()
+    .register("get", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError("Error: presentation ID is required", "gwork slides get <fileId>");
+      }
+      return getPresentation(svc, args[0]!);
+    })
+    .register("list", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError("Error: presentation ID is required", "gwork slides list <fileId>");
+      }
+      return listSlides(svc, args[0]!);
+    })
+    .register("read", (svc, args) => {
+      if (args.length === 0) {
+        throw new ArgumentError(
+          "Error: presentation ID is required",
+          "gwork slides read <fileId> [--notes] [--format text|json]"
+        );
+      }
+      return readSlides(svc, args[0]!, args.slice(1));
+    })
+    .register("thumbnail", (svc, args) => {
+      if (args.length < 2) {
+        throw new ArgumentError(
+          "Error: presentation ID and slide number are required",
+          "gwork slides thumbnail <fileId> <slideNumber>"
+        );
+      }
+      return thumbnailSlide(svc, args[0]!, args.slice(1));
+    });
+}
+
+export async function handleSlidesCommand(
+  subcommand: string,
+  args: string[],
+  account = "default",
+  serviceFactory: (account: string) => SlidesService = (acc) => new SlidesService(acc)
+) {
+  await handleCommandWithRetry({
+    tokenKey: "slides",
+    serviceName: "Slides",
+    account,
+    subcommand,
+    serviceFactory,
+    execute: (svc) => buildSlidesRegistry().execute(subcommand, svc, args),
+  });
+}

--- a/src/services/docs-service.ts
+++ b/src/services/docs-service.ts
@@ -1,0 +1,164 @@
+/**
+ * Google Docs service wrapper for Google Docs API v1.
+ * Provides methods for reading document content and metadata.
+ */
+
+import { google } from "googleapis";
+import { BaseService } from "./base-service.ts";
+import { handleGoogleApiError } from "./error-handler.ts";
+import type { docs_v1 } from "googleapis";
+
+export interface DocMeta {
+  documentId: string;
+  title: string;
+  revisionId: string;
+  suggestionsViewMode: string;
+}
+
+export interface DocContent {
+  documentId: string;
+  title: string;
+  bodyText: string;
+  wordCount: number;
+  headers: string[];
+}
+
+export class DocsService extends BaseService {
+  private docs: docs_v1.Docs | null = null;
+
+  constructor(account = "default") {
+    super(
+      "Docs",
+      [
+        "https://www.googleapis.com/auth/documents.readonly",
+      ],
+      account
+    );
+  }
+
+  override async initialize(): Promise<void> {
+    await super.initialize();
+    this.ensureInitialized();
+    this.docs = google.docs({ version: "v1", auth: this.getAuth() });
+  }
+
+  /**
+   * Get document metadata without full content.
+   */
+  async getDocument(documentId: string): Promise<DocMeta> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.docs!.documents.get({
+        documentId,
+        fields: "documentId,title,revisionId,suggestionsViewMode",
+      });
+
+      return {
+        documentId: result.data.documentId || documentId,
+        title: result.data.title || "",
+        revisionId: result.data.revisionId || "",
+        suggestionsViewMode: result.data.suggestionsViewMode || "",
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "get document");
+    }
+  }
+
+  /**
+   * Read document content as plain text, extracting text from structural elements.
+   */
+  async readContent(documentId: string): Promise<DocContent> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.docs!.documents.get({
+        documentId,
+      });
+
+      const doc = result.data;
+      const textParts: string[] = [];
+      const headers: string[] = [];
+
+      // Extract text from body content
+      if (doc.body?.content) {
+        for (const element of doc.body.content) {
+          if (element.paragraph) {
+            const paragraphText = this.extractParagraphText(element.paragraph);
+
+            // Detect headings
+            const style = element.paragraph.paragraphStyle?.namedStyleType;
+            if (style?.startsWith("HEADING_")) {
+              headers.push(paragraphText.trim());
+            }
+
+            textParts.push(paragraphText);
+          } else if (element.table) {
+            textParts.push(this.extractTableText(element.table));
+          } else if (element.sectionBreak) {
+            textParts.push("\n");
+          }
+        }
+      }
+
+      const bodyText = textParts.join("");
+      const wordCount = bodyText.split(/\s+/).filter(Boolean).length;
+
+      return {
+        documentId: doc.documentId || documentId,
+        title: doc.title || "",
+        bodyText,
+        wordCount,
+        headers,
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "read document");
+    }
+  }
+
+  /**
+   * Extract plain text from a paragraph element.
+   */
+  private extractParagraphText(paragraph: docs_v1.Schema$Paragraph): string {
+    const parts: string[] = [];
+    if (paragraph.elements) {
+      for (const element of paragraph.elements) {
+        if (element.textRun?.content) {
+          parts.push(element.textRun.content);
+        } else if (element.inlineObjectElement) {
+          parts.push("[image]");
+        }
+      }
+    }
+    return parts.join("");
+  }
+
+  /**
+   * Extract plain text from a table element.
+   */
+  private extractTableText(table: docs_v1.Schema$Table): string {
+    const rows: string[] = [];
+    if (table.tableRows) {
+      for (const row of table.tableRows) {
+        const cells: string[] = [];
+        if (row.tableCells) {
+          for (const cell of row.tableCells) {
+            const cellText: string[] = [];
+            if (cell.content) {
+              for (const element of cell.content) {
+                if (element.paragraph) {
+                  cellText.push(this.extractParagraphText(element.paragraph).trim());
+                }
+              }
+            }
+            cells.push(cellText.join(" "));
+          }
+        }
+        rows.push(cells.join("\t"));
+      }
+    }
+    return rows.join("\n") + "\n";
+  }
+}

--- a/src/services/drive-service.ts
+++ b/src/services/drive-service.ts
@@ -150,23 +150,41 @@ export class DriveService extends BaseService {
         "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
       };
 
-      // Format-specific overrides for Google Sheets
-      const sheetExportFormats: Record<string, { mime: string; ext: string }> = {
-        csv: { mime: "text/csv", ext: ".csv" },
-        tsv: { mime: "text/tab-separated-values", ext: ".tsv" },
-        xlsx: { mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ext: ".xlsx" },
-        pdf: { mime: "application/pdf", ext: ".pdf" },
+      // Format-specific overrides per Google Workspace file type
+      const formatOverrides: Record<string, Record<string, string>> = {
+        "application/vnd.google-apps.spreadsheet": {
+          csv: "text/csv",
+          tsv: "text/tab-separated-values",
+          xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          pdf: "application/pdf",
+        },
+        "application/vnd.google-apps.document": {
+          txt: "text/plain",
+          text: "text/plain",
+          pdf: "application/pdf",
+          html: "text/html",
+          rtf: "application/rtf",
+          epub: "application/epub+zip",
+          docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          md: "text/plain",
+        },
+        "application/vnd.google-apps.presentation": {
+          pdf: "application/pdf",
+          txt: "text/plain",
+          text: "text/plain",
+          pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        },
       };
 
       const resolvedDest = path.resolve(destPath);
       const dest = fs.createWriteStream(resolvedDest);
 
-      // Allow format override for Sheets (e.g., --format csv)
+      // Allow format override for Workspace files (e.g., --format csv, --format txt)
       let exportMime = exportMimeMap[mimeType];
-      if (format && mimeType === "application/vnd.google-apps.spreadsheet") {
-        const formatOverride = sheetExportFormats[format.toLowerCase()];
-        if (formatOverride) {
-          exportMime = formatOverride.mime;
+      if (format && formatOverrides[mimeType]) {
+        const overrideMime = formatOverrides[mimeType][format.toLowerCase()];
+        if (overrideMime) {
+          exportMime = overrideMime;
         }
       }
 

--- a/src/services/slides-service.ts
+++ b/src/services/slides-service.ts
@@ -1,0 +1,193 @@
+/**
+ * Google Slides service wrapper for Google Slides API v1.
+ * Provides methods for reading presentation metadata and slide content.
+ */
+
+import { google } from "googleapis";
+import { BaseService } from "./base-service.ts";
+import { handleGoogleApiError } from "./error-handler.ts";
+import type { slides_v1 } from "googleapis";
+
+export interface SlideInfo {
+  objectId: string;
+  pageType: string;
+  title: string;
+  speakerNotes: string;
+}
+
+export interface PresentationMeta {
+  presentationId: string;
+  title: string;
+  locale: string;
+  pageSize: { width: number; height: number; unit: string };
+  slideCount: number;
+  slides: SlideInfo[];
+  masterCount: number;
+  layoutCount: number;
+}
+
+export class SlidesService extends BaseService {
+  private slides: slides_v1.Slides | null = null;
+
+  constructor(account = "default") {
+    super(
+      "Slides",
+      [
+        "https://www.googleapis.com/auth/presentations.readonly",
+      ],
+      account
+    );
+  }
+
+  override async initialize(): Promise<void> {
+    await super.initialize();
+    this.ensureInitialized();
+    this.slides = google.slides({ version: "v1", auth: this.getAuth() });
+  }
+
+  /**
+   * Get full presentation metadata including slide list.
+   */
+  async getPresentation(presentationId: string): Promise<PresentationMeta> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.slides!.presentations.get({
+        presentationId,
+      });
+
+      const data = result.data;
+      const pageSize = data.pageSize || {};
+      const width = pageSize.width?.magnitude || 0;
+      const height = pageSize.height?.magnitude || 0;
+      const unit = pageSize.width?.unit || "EMU";
+
+      const allSlides = (data.slides || []).map((slide, index) =>
+        this.mapSlide(slide, index)
+      );
+
+      return {
+        presentationId: data.presentationId || presentationId,
+        title: data.title || "",
+        locale: data.locale || "",
+        pageSize: { width, height, unit },
+        slideCount: allSlides.length,
+        slides: allSlides,
+        masterCount: (data.masters || []).length,
+        layoutCount: (data.layouts || []).length,
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "get presentation");
+    }
+  }
+
+  /**
+   * Read text content from all slides in the presentation.
+   */
+  async readContent(presentationId: string): Promise<{ title: string; slides: SlideInfo[] }> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.slides!.presentations.get({
+        presentationId,
+      });
+
+      const data = result.data;
+      const slides = (data.slides || []).map((slide, index) =>
+        this.mapSlide(slide, index)
+      );
+
+      return {
+        title: data.title || "",
+        slides,
+      };
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "read presentation");
+    }
+  }
+
+  /**
+   * Get a thumbnail URL for a specific slide.
+   */
+  async getSlideThumbnail(
+    presentationId: string,
+    pageObjectId: string
+  ): Promise<string> {
+    await this.initialize();
+    this.ensureInitialized();
+
+    try {
+      const result = await this.slides!.presentations.pages.getThumbnail({
+        presentationId,
+        pageObjectId,
+        "thumbnailProperties.thumbnailSize": "LARGE",
+      });
+
+      return result.data.contentUrl || "";
+    } catch (error: unknown) {
+      handleGoogleApiError(error, "get slide thumbnail");
+    }
+  }
+
+  /**
+   * Map a slide page to SlideInfo, extracting title and speaker notes.
+   */
+  private mapSlide(slide: slides_v1.Schema$Page, index: number): SlideInfo {
+    return {
+      objectId: slide.objectId || "",
+      pageType: slide.pageType || "SLIDE",
+      title: this.extractSlideTitle(slide, index),
+      speakerNotes: this.extractSpeakerNotes(slide),
+    };
+  }
+
+  /**
+   * Extract the title text from a slide's page elements.
+   */
+  private extractSlideTitle(slide: slides_v1.Schema$Page, index: number): string {
+    if (slide.pageElements) {
+      for (const element of slide.pageElements) {
+        const shape = element.shape;
+        if (shape?.placeholder?.type === "TITLE" || shape?.placeholder?.type === "CENTERED_TITLE") {
+          const text = this.extractShapeText(shape);
+          if (text.trim()) return text.trim();
+        }
+      }
+    }
+    return `Slide ${index + 1}`;
+  }
+
+  /**
+   * Extract speaker notes from a slide.
+   */
+  private extractSpeakerNotes(slide: slides_v1.Schema$Page): string {
+    const notes = slide.slideProperties?.notesPage;
+    if (!notes?.pageElements) return "";
+
+    for (const element of notes.pageElements) {
+      const shape = element.shape;
+      if (shape?.placeholder?.type === "BODY") {
+        const text = this.extractShapeText(shape);
+        if (text.trim()) return text.trim();
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Extract plain text from a shape's text content.
+   */
+  private extractShapeText(shape: slides_v1.Schema$Shape): string {
+    const parts: string[] = [];
+    if (shape.text?.textElements) {
+      for (const te of shape.text.textElements) {
+        if (te.textRun?.content) {
+          parts.push(te.textRun.content);
+        }
+      }
+    }
+    return parts.join("");
+  }
+}


### PR DESCRIPTION
## Summary
- New `gwork docs` command group: `get` (metadata) and `read` (text extraction with heading detection, `--headers` for TOC, `--format json`)
- New `gwork slides` command group: `get` (metadata), `list` (slide titles + notes preview), `read` (full content + speaker notes, `--notes` filter), `thumbnail` (get slide thumbnail URL)
- Extended `drive download --format` to support all Google Workspace types:
  - Docs: txt, pdf, html, rtf, epub, docx, md
  - Slides: pdf, txt, pptx
  - Sheets: csv, tsv, xlsx, pdf (existing)

## Test plan
- [x] All 256 existing tests pass
- [x] ESLint clean
- [x] TypeScript type check clean
- [x] `gwork docs --help` and `gwork slides --help` display correctly
- [ ] Manual: `gwork docs read <docId>` displays document text
- [ ] Manual: `gwork slides list <presentationId>` lists slides
- [ ] Manual: `gwork drive download <docId> --format txt` exports as plain text