### PR TITLE
fix(drive): resolve shared file access failures

### DIFF
--- a/src/services/drive-service.ts
+++ b/src/services/drive-service.ts
@@ -58,6 +58,20 @@ export class DriveService extends BaseService {
     await super.initialize();
     this.ensureInitialized();
     this.drive = google.drive({ version: "v3", auth: this.getAuth() });
+
+    // When a specific account (not "default") is requested, verify the authenticated
+    // token actually belongs to that account. Without this check, a mismatched token
+    // silently queries the wrong user's Drive, returning 404 for shared files.
+    if (this.account !== "default") {
+      const about = await this.drive.about.get({ fields: "user" });
+      const authenticatedEmail = about.data.user?.emailAddress ?? "";
+      if (authenticatedEmail.toLowerCase() !== this.account.toLowerCase()) {
+        throw new Error(
+          `Account mismatch: token is authenticated as "${authenticatedEmail}" but "--account ${this.account}" was requested. ` +
+          `Run "gwork drive list --account ${this.account}" to re-authenticate the correct account.`
+        );
+      }
+    }
   }
 
   // ============= FILE OPERATIONS =============
@@ -82,6 +96,7 @@ export class DriveService extends BaseService {
         fields: "files(id,name,mimeType,size,modifiedTime,createdTime,parents,webViewLink,shared)",
         q,
         orderBy,
+        corpora: "allDrives",
         supportsAllDrives: true,
         includeItemsFromAllDrives: true,
       });
@@ -117,6 +132,7 @@ export class DriveService extends BaseService {
         fields: "files(id,name,mimeType,size,modifiedTime,createdTime,parents,webViewLink,shared)",
         q: `name contains '${query.replace(/'/g, "\\'")}' and trashed = false`,
         orderBy: "modifiedTime desc",
+        corpora: "allDrives",
         supportsAllDrives: true,
         includeItemsFromAllDrives: true,
       });


### PR DESCRIPTION
## Summary

Fixes #113 — `gwork drive get/download` returns "file not found" for files shared with the authenticated account.

**Root causes addressed:**

1. **Missing account verification** — `DriveService` never verified the token matched the `--account` flag. A mismatched token (wrong Google account selected during OAuth) silently queried the wrong user's Drive, returning 404 for files the intended account could access. Now uses `drive.about.get({ fields: "user" })` to detect mismatches early, matching the pattern already used by `MailService`.

2. **Missing `corpora: "allDrives"` on list/search** — `listFiles` and `searchFiles` relied on the default corpora (`user`), which may exclude Shared Drive items. Added `corpora: "allDrives"` to ensure files in Shared Drives appear in results.

## Changes

- `src/services/drive-service.ts`: Add account verification in `initialize()`, add `corpora: "allDrives"` to `listFiles` and `searchFiles`

## Test plan

- [x] `bunx tsc --noEmit` — passes
- [x] `bun run lint` — passes
- [x] `bun test --concurrent` — 256/256 tests pass