### PR TITLE
refactor(commands): extract shared extractFlag helper

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { DocsService } from "../services/docs-service.ts";
 import { ArgumentError } from "../services/errors.ts";
+import { extractFlag } from "../utils/args.ts";
 import { handleCommandWithRetry } from "../utils/command-handler.ts";
 import { CommandRegistry } from "./registry.ts";
 
@@ -50,11 +51,6 @@ async function readDoc(svc: DocsService, documentId: string, args: string[]): Pr
   } else {
     console.log(content.bodyText);
   }
-}
-
-function extractFlag(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  return idx !== -1 ? args[idx + 1] : undefined;
 }
 
 async function createDoc(svc: DocsService, title: string): Promise<void> {

--- a/src/commands/sheets.ts
+++ b/src/commands/sheets.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { SheetsService } from "../services/sheets-service.ts";
 import { ArgumentError } from "../services/errors.ts";
+import { extractFlag } from "../utils/args.ts";
 import { handleCommandWithRetry } from "../utils/command-handler.ts";
 import { CommandRegistry } from "./registry.ts";
 
@@ -202,14 +203,6 @@ async function appendRows(svc: SheetsService, spreadsheetId: string, args: strin
   spinner.stop();
 
   console.log(`Appended ${chalk.bold(String(result.updatedRows))} row(s) to ${chalk.cyan(result.updatedRange)}`);
-}
-
-/**
- * Extract a flag value from args (e.g., --format csv → "csv").
- */
-function extractFlag(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  return idx !== -1 ? args[idx + 1] : undefined;
 }
 
 function buildSheetsRegistry(): CommandRegistry<SheetsService> {

--- a/src/commands/slides.ts
+++ b/src/commands/slides.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { SlidesService } from "../services/slides-service.ts";
 import { ArgumentError } from "../services/errors.ts";
+import { extractFlag } from "../utils/args.ts";
 import { handleCommandWithRetry } from "../utils/command-handler.ts";
 import { CommandRegistry } from "./registry.ts";
 
@@ -105,11 +106,6 @@ async function createPresentation(svc: SlidesService, title: string): Promise<vo
   console.log(`ID:      ${meta.presentationId}`);
   console.log(`Slides:  ${meta.slideCount}`);
   console.log(`Link:    https://docs.google.com/presentation/d/${meta.presentationId}/edit`);
-}
-
-function extractFlag(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  return idx !== -1 ? args[idx + 1] : undefined;
 }
 
 function truncate(text: string, max: number): string {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -11,6 +11,14 @@ export interface ParsedArgs {
 // downstream parser that only matches the literal `--flag` token still finds
 // its value. Tokens not starting with `-` and tokens without `=` are left
 // untouched. Used at the CLI entry point as a single normalization pass.
+// Looks up `--flag` in args and returns the following token, or undefined if
+// the flag is missing or has no value. Assumes args have been normalized by
+// `normalizeArgs` so `--flag=value` callers don't need a separate code path.
+export function extractFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
 export function normalizeArgs(args: string[]): string[] {
   const out: string[] = [];
   let sawDoubleDash = false;


### PR DESCRIPTION
## Summary

Dedupes the identical `extractFlag` helper across `docs.ts`, `slides.ts`, and `sheets.ts`. Moves it to `src/utils/args.ts` alongside `parseAccount` and `normalizeArgs`.

Closes #119.

## What changed

- `src/utils/args.ts`: Added `extractFlag(args, flag)`.
- `src/commands/{docs,slides,sheets}.ts`: Removed local `extractFlag` definitions; import from `src/utils/args.ts`.

## Why

Three identical copies of a six-line helper. Mentioned during code review of #111/#112. Consolidating in `args.ts` keeps argument-parsing primitives together.

## Testing

- `bun test --concurrent` → 277/277 pass
- `bunx tsc --noEmit` → clean
- `bun run lint` → clean

## Risk / Rollout

Zero. The helper body is byte-identical to the three deleted copies; `normalizeArgs` at the CLI entry already handles `--flag=value` before this helper is called.